### PR TITLE
 Add more usage examples to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ The module provisions the following resources:
 ## Usage
 
 
-For a complete example, see [examples/complete](examples/complete)
+Module usage examples:
+
+- [examples/complete](examples/complete) - complete example
+- [terraform-root-modules/eks](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks) - Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures
+- [terraform-root-modules/eks-backing-services-peering](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks-backing-services-peering) - example of VPC peering between the EKS VPC and backing services VPC
 
 ```hcl
 provider "aws" {

--- a/README.yaml
+++ b/README.yaml
@@ -75,7 +75,11 @@ introduction: |-
 # How to use this project
 usage: |-
 
-  For a complete example, see [examples/complete](examples/complete)
+  Module usage examples:
+
+  - [examples/complete](examples/complete) - complete example
+  - [terraform-root-modules/eks](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks) - Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures
+  - [terraform-root-modules/eks-backing-services-peering](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks-backing-services-peering) - example of VPC peering between the EKS VPC and backing services VPC
 
   ```hcl
   provider "aws" {


### PR DESCRIPTION
## what
*  Add more usage examples to README

## why
* Add references to [terraform-root-modules](https://github.com/cloudposse/terraform-root-modules), Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures

*  Show all our examples of EKS module invocation
    - [examples/complete](examples/complete) - complete example
    - [terraform-root-modules/eks](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks) - Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures
    - [terraform-root-modules/eks-backing-services-peering](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks-backing-services-peering) - example of VPC peering between the EKS VPC and backing services VPC
