### PR TITLE
Upgrade to terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,22 +1,22 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("cluster")))}"]
-  tags       = "${var.tags}"
-  enabled    = "${var.enabled}"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = compact(concat(var.attributes, ["cluster"]))
+  tags       = var.tags
+  enabled    = var.enabled
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.enabled == "true" ? 1 : 0}"
+  count = var.enabled ? 1 : 0
 
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["eks.amazonaws.com"]
     }
@@ -24,109 +24,119 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "${module.label.id}"
-  assume_role_policy = "${join("", data.aws_iam_policy_document.assume_role.*.json)}"
+  count              = var.enabled ? 1 : 0
+  name               = module.label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cluster_policy" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = var.enabled ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  role       = "${aws_iam_role.default.name}"
+  role       = aws_iam_role.default[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_service_policy" {
-  count      = "${var.enabled == "true" ? 1 : 0}"
+  count      = var.enabled ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = "${join("", aws_iam_role.default.*.name)}"
+  role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_security_group" "default" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
-  name        = "${module.label.id}"
+  count       = var.enabled ? 1 : 0
+  name        = module.label.id
   description = "Security Group for EKS cluster"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${module.label.tags}"
+  vpc_id      = var.vpc_id
+  tags        = module.label.tags
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = "${var.enabled == "true" ? 1 : 0}"
+  count             = var.enabled ? 1 : 0
   description       = "Allow all egress traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_workers" {
-  count                    = "${var.enabled == "true" ? var.workers_security_group_count : 0}"
+  count                    = var.enabled ? var.workers_security_group_count : 0
   description              = "Allow the cluster to receive communication from the worker nodes"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  source_security_group_id = "${element(var.workers_security_group_ids, count.index)}"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+  source_security_group_id = element(var.workers_security_group_ids, count.index)
+  security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = "${var.enabled == "true" ? length(var.allowed_security_groups) : 0}"
+  count                    = var.enabled ? length(var.allowed_security_groups) : 0
   description              = "Allow inbound traffic from existing Security Groups"
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+  source_security_group_id = element(var.allowed_security_groups, count.index)
+  security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = "${var.enabled == "true" && length(var.allowed_cidr_blocks) > 0 ? 1 : 0}"
+  count             = var.enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   from_port         = 0
   to_port           = 65535
   protocol          = "-1"
-  cidr_blocks       = ["${var.allowed_cidr_blocks}"]
-  security_group_id = "${join("", aws_security_group.default.*.id)}"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = join("", aws_security_group.default.*.id)
   type              = "ingress"
 }
 
 resource "aws_eks_cluster" "default" {
-  count                     = "${var.enabled == "true" ? 1 : 0}"
-  name                      = "${module.label.id}"
-  role_arn                  = "${join("", aws_iam_role.default.*.arn)}"
-  version                   = "${var.kubernetes_version}"
-  enabled_cluster_log_types = ["${var.enabled_cluster_log_types}"]
+  count                     = var.enabled ? 1 : 0
+  name                      = module.label.id
+  role_arn                  = join("", aws_iam_role.default.*.arn)
+  version                   = var.kubernetes_version
+  enabled_cluster_log_types = var.enabled_cluster_log_types
 
   vpc_config {
-    security_group_ids      = ["${join("", aws_security_group.default.*.id)}"]
-    subnet_ids              = ["${var.subnet_ids}"]
-    endpoint_private_access = "${var.endpoint_private_access}"
-    endpoint_public_access  = "${var.endpoint_public_access}"
+    security_group_ids      = [join("", aws_security_group.default.*.id)]
+    subnet_ids              = var.subnet_ids
+    endpoint_private_access = var.endpoint_private_access
+    endpoint_public_access  = var.endpoint_public_access
   }
 
   depends_on = [
-    "aws_iam_role_policy_attachment.amazon_eks_cluster_policy",
-    "aws_iam_role_policy_attachment.amazon_eks_service_policy",
+    aws_iam_role_policy_attachment.amazon_eks_cluster_policy,
+    aws_iam_role_policy_attachment.amazon_eks_service_policy,
   ]
 }
 
 locals {
-  certificate_authority_data_list          = "${coalescelist(aws_eks_cluster.default.*.certificate_authority, list(list(map("data", ""))))}"
-  certificate_authority_data_list_internal = "${local.certificate_authority_data_list[0]}"
-  certificate_authority_data_map           = "${local.certificate_authority_data_list_internal[0]}"
-  certificate_authority_data               = "${local.certificate_authority_data_map["data"]}"
+  certificate_authority_data_list = coalescelist(
+    aws_eks_cluster.default.*.certificate_authority,
+    [
+      [
+        {
+          "data" = ""
+        },
+      ],
+    ],
+  )
+  certificate_authority_data_list_internal = local.certificate_authority_data_list[0]
+  certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
+  certificate_authority_data               = local.certificate_authority_data_map["data"]
 }
 
 data "template_file" "kubeconfig" {
-  count    = "${var.enabled == "true" ? 1 : 0}"
-  template = "${file("${path.module}/kubeconfig.tpl")}"
+  count    = var.enabled ? 1 : 0
+  template = file("${path.module}/kubeconfig.tpl")
 
-  vars {
-    server                     = "${join("", aws_eks_cluster.default.*.endpoint)}"
-    certificate_authority_data = "${local.certificate_authority_data}"
-    cluster_name               = "${module.label.id}"
+  vars = {
+    server                     = join("", aws_eks_cluster.default.*.endpoint)
+    certificate_authority_data = local.certificate_authority_data
+    cluster_name               = module.label.id
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,44 +1,45 @@
 output "kubeconfig" {
   description = "`kubeconfig` configuration to connect to the cluster using `kubectl`. https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#configuring-kubectl-for-eks"
-  value       = "${join("", data.template_file.kubeconfig.*.rendered)}"
+  value       = join("", data.template_file.kubeconfig.*.rendered)
 }
 
 output "security_group_id" {
   description = "ID of the EKS cluster Security Group"
-  value       = "${join("", aws_security_group.default.*.id)}"
+  value       = join("", aws_security_group.default.*.id)
 }
 
 output "security_group_arn" {
   description = "ARN of the EKS cluster Security Group"
-  value       = "${join("", aws_security_group.default.*.arn)}"
+  value       = join("", aws_security_group.default.*.arn)
 }
 
 output "security_group_name" {
   description = "Name of the EKS cluster Security Group"
-  value       = "${join("", aws_security_group.default.*.name)}"
+  value       = join("", aws_security_group.default.*.name)
 }
 
 output "eks_cluster_id" {
   description = "The name of the cluster"
-  value       = "${join("", aws_eks_cluster.default.*.id)}"
+  value       = join("", aws_eks_cluster.default.*.id)
 }
 
 output "eks_cluster_arn" {
   description = "The Amazon Resource Name (ARN) of the cluster"
-  value       = "${join("", aws_eks_cluster.default.*.arn)}"
+  value       = join("", aws_eks_cluster.default.*.arn)
 }
 
 output "eks_cluster_certificate_authority_data" {
   description = "The base64 encoded certificate data required to communicate with the cluster"
-  value       = "${local.certificate_authority_data}"
+  value       = local.certificate_authority_data
 }
 
 output "eks_cluster_endpoint" {
   description = "The endpoint for the Kubernetes API server"
-  value       = "${join("", aws_eks_cluster.default.*.endpoint)}"
+  value       = join("", aws_eks_cluster.default.*.endpoint)
 }
 
 output "eks_cluster_version" {
   description = "The Kubernetes server version of the cluster"
-  value       = "${join("", aws_eks_cluster.default.*.version)}"
+  value       = join("", aws_eks_cluster.default.*.version)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,73 +1,73 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Environment, e.g. 'testing', 'UAT'"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "app"
   description = "Solution name, e.g. 'app' or 'cluster'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = bool
   description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
-  default     = "true"
+  default     = true
 }
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "VPC ID for the EKS cluster"
 }
 
 variable "subnet_ids" {
   description = "A list of subnet IDs to launch the cluster in"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "allowed_security_groups" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of Security Group IDs to be allowed to connect to the EKS cluster"
 }
 
 variable "allowed_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of CIDR blocks to be allowed to connect to the EKS cluster"
 }
 
 variable "workers_security_group_ids" {
-  type        = "list"
+  type        = list(string)
   description = "Security Group IDs of the worker nodes"
 }
 
@@ -76,25 +76,26 @@ variable "workers_security_group_count" {
 }
 
 variable "kubernetes_version" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used."
 }
 
 variable "endpoint_private_access" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is false"
 }
 
 variable "endpoint_public_access" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true"
 }
 
 variable "enabled_cluster_log_types" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`]"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This moves this module to terraform 0.12, the example isn't ported, as some of those modules aren't 0.12 compliant yet, but this is working with our EKS clusters.

I notice there are also tests being added as part of the other 0.12 upgrades for the cloudposse modules, this does not add those, but would be happy to help, I just wasn't clear how to go about that