### PR TITLE
Add ability to change local exec interpreter from variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Available targets:
 | endpoint_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true | bool | `true` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
+| local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |
 | map_additional_iam_roles | Additional IAM roles to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |

--- a/auth.tf
+++ b/auth.tf
@@ -27,8 +27,8 @@ locals {
   certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
   certificate_authority_data               = local.certificate_authority_data_map["data"]
 
-  configmap_auth_template_file = "${path.module}/configmap-auth.yaml.tpl"
-  configmap_auth_file          = "${path.module}/configmap-auth.yaml"
+  configmap_auth_template_file = join("/", [path.module, "configmap-auth.yaml.tpl"])
+  configmap_auth_file          = join("/", [path.module, "configmap-auth.yaml"])
 
   cluster_name = join("", aws_eks_cluster.default.*.id)
 

--- a/auth.tf
+++ b/auth.tf
@@ -82,7 +82,8 @@ resource "null_resource" "apply_configmap_auth" {
   depends_on = [aws_eks_cluster.default, local_file.configmap_auth]
 
   provisioner "local-exec" {
-    command = <<EOT
+    interpreter = [var.local_exec_interpreter, "-c"]
+    command     = <<EOT
       while [[ ! -e ${local.configmap_auth_file} ]] ; do sleep 1; done && \
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} && \
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,7 @@
 | endpoint_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true | bool | `true` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
+| local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |
 | map_additional_iam_roles | Additional IAM roles to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -147,3 +147,9 @@ variable "kubeconfig_path" {
   default     = "~/.kube/config"
   description = "The path to `kubeconfig` file"
 }
+
+variable "local_exec_interpreter" {
+  type        = string
+  default     = "/bin/sh"
+  description = "shell to use for local exec"
+}


### PR DESCRIPTION
### Background

We ran into issue where terraform local-exec was failing in travis CI as default interpreter was `/bin/sh` which was exiting with non zero status code. We had to change the interpreter to `/bin/bash` to successfully run the local-exec to apply configmap-auth via travis CI.

Hence, I have created a PR that will inject the interpreter type as a variable to this module.