### PR TITLE
Allow installing external packages. Allow assuming IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Available targets:
 | apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Available targets:
 | apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |
+| aws_cli_assume_role_session_name | An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Available targets:
 | external_packages_install_path | Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers | string | `` | no |
 | install_aws_cli | Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
 | install_kubectl | Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
+| jq_version | Version of `jq` to download to extract temporaly credentials after running `aws sts assume-role` if AWS CLI needs to assume role to access the cluster (if variable `aws_cli_assume_role_arn` is set) | string | `1.6` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |

--- a/README.md
+++ b/README.md
@@ -305,7 +305,11 @@ Available targets:
 | enabled_cluster_log_types | A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`] | list(string) | `<list>` | no |
 | endpoint_private_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is false | bool | `false` | no |
 | endpoint_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true | bool | `true` | no |
+| external_packages_install_path | Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers | string | `` | no |
+| install_aws_cli | Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
+| install_kubectl | Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
+| kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
 | local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,44 @@ The module provisions the following resources:
 - EKS cluster of master nodes that can be used together with the [terraform-aws-eks-workers](https://github.com/cloudposse/terraform-aws-eks-workers) module to create a full-blown cluster
 - IAM Role to allow the cluster to access other AWS services
 - Security Group which is used by EKS workers to connect to the cluster and kubelets and pods to receive communication from the cluster control plane (see [terraform-aws-eks-workers](https://github.com/cloudposse/terraform-aws-eks-workers))
-- The module generates `kubeconfig` configuration to connect to the cluster using `kubectl`
+- The module creates and automatically applies (via `kubectl apply`) an authentication ConfigMap to allow the wrokers nodes to join the cluster and to add additional users/roles/accounts
+
+### Works with [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html)
+
+To run on Terraform Cloud, set the following variables:
+
+  ```hcl
+      install_aws_cli                                = true
+      install_kubectl                                = true
+      external_packages_install_path                 = "~/.terraform/bin"
+      kubeconfig_path                                = "~/.kube/config"
+      configmap_auth_file                            = "/home/terraform/.terraform/configmap-auth.yaml"
+
+      # Optional
+      aws_eks_update_kubeconfig_additional_arguments = "--verbose"
+      aws_cli_assume_role_arn                        = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+      aws_cli_assume_role_session_name               = "eks_cluster_example_session"
+  ```
+
+  Terraform Cloud executes `terraform plan/apply` on workers running Ubuntu.
+  For the module to provision the authentication ConfigMap (to allow the EKS worker nodes to join the EKS cluster and to add additional users/roles/accounts),
+  AWS CLI and `kubectl` need to be installed on Terraform Cloud workers.
+
+  To install the required external packages, set the variables `install_aws_cli` and `install_kubectl` to `true` and specify `external_packages_install_path`, `kubeconfig_path` and `configmap_auth_file`.
+
+  See [auth.tf](auth.tf) and [Installing Software in the Run Environment](https://www.terraform.io/docs/cloud/run/install-software.html) for more details.
+
+  In a multi-account architecture, we might have a separate identity account where we provision all IAM users, and other accounts (e.g. `prod`, `staging`, `dev`, `audit`, `testing`)
+  where all other AWS resources are provisioned. The IAM Users from the identity account can assume IAM roles to access the other accounts.
+
+  In this case, we provide Terraform Cloud with access keys (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) for an IAM User from the identity account
+  and allow it to assume an IAM Role into the AWS account where the module gets provisioned.
+
+  To support this, the module can assume an IAM role before executing the command `aws eks update-kubeconfig` when applying the auth ConfigMap.
+
+  Set variable `aws_cli_assume_role_arn` to the Amazon Resource Name (ARN) of the role to assume and variable `aws_cli_assume_role_session_name` to the identifier for the assumed role session.
+
+  See [auth.tf](auth.tf) and [assume-role](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html) for more details.
 
 ## Usage
 
@@ -95,9 +132,12 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 
 
 
-Module usage examples:
+For a complete example, see [examples/complete](examples/complete).
 
-- [examples/complete](examples/complete) - complete example
+For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
+
+Other examples:
+
 - [terraform-root-modules/eks](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks) - Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures
 - [terraform-root-modules/eks-backing-services-peering](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks-backing-services-peering) - example of VPC peering between the EKS VPC and backing services VPC
 
@@ -123,9 +163,9 @@ Module usage examples:
     tags = merge(var.tags, map("kubernetes.io/cluster/${module.label.id}", "shared"))
 
     # Unfortunately, most_recent (https://github.com/cloudposse/terraform-aws-eks-workers/blob/34a43c25624a6efb3ba5d2770a601d7cb3c0d391/main.tf#L141)
-    # variable does not work as expected, if you are not going to use custom ami you should
+    # variable does not work as expected, if you are not going to use custom AMI you should
     # enforce usage of eks_worker_ami_name_filter variable to set the right kubernetes version for EKS workers,
-    # otherwise will be used the first version of Kubernetes supported by AWS (v1.11) for EKS workers but
+    # otherwise the first version of Kubernetes supported by AWS (v1.11) for EKS workers will be used, but
     # EKS control plane will use the version specified by kubernetes_version variable.
     eks_worker_ami_name_filter = "amazon-eks-node-${var.kubernetes_version}*"
   }
@@ -202,9 +242,6 @@ Module usage examples:
 Module usage with two worker groups:
 
 ```hcl
-  {
-  ...
-
   module "eks_workers" {
     source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
     namespace                          = var.namespace
@@ -270,7 +307,46 @@ Module usage with two worker groups:
 
     workers_role_arns          = [module.eks_workers.workers_role_arn, module.eks_workers_2.workers_role_arn]
     workers_security_group_ids = [module.eks_workers.security_group_id, module.eks_workers_2.security_group_id]
-    
+  }
+```
+
+Module usage on [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html):
+
+```hcl
+  provider "aws" {
+    region = "us-east-2"
+
+    assume_role {
+      role_arn = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+    }
+  }
+
+  module "eks_cluster" {
+    source                 = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+    namespace              = var.namespace
+    stage                  = var.stage
+    name                   = var.name
+    attributes             = var.attributes
+    tags                   = var.tags
+    region                 = "us-east-2"
+    vpc_id                 = module.vpc.vpc_id
+    subnet_ids             = module.subnets.public_subnet_ids
+
+    local_exec_interpreter = "/bin/bash"
+    kubernetes_version     = "1.14"
+
+    workers_role_arns          = [module.eks_workers.workers_role_arn]
+    workers_security_group_ids = [module.eks_workers.security_group_id]
+
+    # Terraform Cloud configurations
+    kubeconfig_path                                = "~/.kube/config"
+    configmap_auth_file                            = "/home/terraform/.terraform/configmap-auth.yaml"
+    install_aws_cli                                = true
+    install_kubectl                                = true
+    external_packages_install_path                 = "~/.terraform/bin"
+    aws_eks_update_kubeconfig_additional_arguments = "--verbose"
+    aws_cli_assume_role_arn                        = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+    aws_cli_assume_role_session_name               = "eks_cluster_example_session"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Available targets:
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
-| local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
+| local_exec_interpreter | shell to use for local exec | string | `/bin/bash` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |
 | map_additional_iam_roles | Additional IAM roles to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -70,14 +70,54 @@ introduction: |-
   - EKS cluster of master nodes that can be used together with the [terraform-aws-eks-workers](https://github.com/cloudposse/terraform-aws-eks-workers) module to create a full-blown cluster
   - IAM Role to allow the cluster to access other AWS services
   - Security Group which is used by EKS workers to connect to the cluster and kubelets and pods to receive communication from the cluster control plane (see [terraform-aws-eks-workers](https://github.com/cloudposse/terraform-aws-eks-workers))
-  - The module generates `kubeconfig` configuration to connect to the cluster using `kubectl`
+  - The module creates and automatically applies (via `kubectl apply`) an authentication ConfigMap to allow the wrokers nodes to join the cluster and to add additional users/roles/accounts
+
+  ### Works with [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html)
+
+  To run on Terraform Cloud, set the following variables:
+
+    ```hcl
+        install_aws_cli                                = true
+        install_kubectl                                = true
+        external_packages_install_path                 = "~/.terraform/bin"
+        kubeconfig_path                                = "~/.kube/config"
+        configmap_auth_file                            = "/home/terraform/.terraform/configmap-auth.yaml"
+
+        # Optional
+        aws_eks_update_kubeconfig_additional_arguments = "--verbose"
+        aws_cli_assume_role_arn                        = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+        aws_cli_assume_role_session_name               = "eks_cluster_example_session"
+    ```
+
+    Terraform Cloud executes `terraform plan/apply` on workers running Ubuntu.
+    For the module to provision the authentication ConfigMap (to allow the EKS worker nodes to join the EKS cluster and to add additional users/roles/accounts),
+    AWS CLI and `kubectl` need to be installed on Terraform Cloud workers.
+
+    To install the required external packages, set the variables `install_aws_cli` and `install_kubectl` to `true` and specify `external_packages_install_path`, `kubeconfig_path` and `configmap_auth_file`.
+
+    See [auth.tf](auth.tf) and [Installing Software in the Run Environment](https://www.terraform.io/docs/cloud/run/install-software.html) for more details.
+
+    In a multi-account architecture, we might have a separate identity account where we provision all IAM users, and other accounts (e.g. `prod`, `staging`, `dev`, `audit`, `testing`)
+    where all other AWS resources are provisioned. The IAM Users from the identity account can assume IAM roles to access the other accounts.
+
+    In this case, we provide Terraform Cloud with access keys (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) for an IAM User from the identity account
+    and allow it to assume an IAM Role into the AWS account where the module gets provisioned.
+
+    To support this, the module can assume an IAM role before executing the command `aws eks update-kubeconfig` when applying the auth ConfigMap.
+
+    Set variable `aws_cli_assume_role_arn` to the Amazon Resource Name (ARN) of the role to assume and variable `aws_cli_assume_role_session_name` to the identifier for the assumed role session.
+
+    See [auth.tf](auth.tf) and [assume-role](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html) for more details.
 
 # How to use this project
 usage: |-
 
-  Module usage examples:
+  For a complete example, see [examples/complete](examples/complete).
 
-  - [examples/complete](examples/complete) - complete example
+  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
+
+  Other examples:
+
   - [terraform-root-modules/eks](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks) - Cloud Posse's service catalog of "root module" invocations for provisioning reference architectures
   - [terraform-root-modules/eks-backing-services-peering](https://github.com/cloudposse/terraform-root-modules/tree/master/aws/eks-backing-services-peering) - example of VPC peering between the EKS VPC and backing services VPC
 
@@ -101,11 +141,11 @@ usage: |-
       # for EKS and Kubernetes to discover and manage networking resources
       # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
       tags = merge(var.tags, map("kubernetes.io/cluster/${module.label.id}", "shared"))
-  
+
       # Unfortunately, most_recent (https://github.com/cloudposse/terraform-aws-eks-workers/blob/34a43c25624a6efb3ba5d2770a601d7cb3c0d391/main.tf#L141)
-      # variable does not work as expected, if you are not going to use custom ami you should
+      # variable does not work as expected, if you are not going to use custom AMI you should
       # enforce usage of eks_worker_ami_name_filter variable to set the right kubernetes version for EKS workers,
-      # otherwise will be used the first version of Kubernetes supported by AWS (v1.11) for EKS workers but
+      # otherwise the first version of Kubernetes supported by AWS (v1.11) for EKS workers will be used, but
       # EKS control plane will use the version specified by kubernetes_version variable.
       eks_worker_ami_name_filter = "amazon-eks-node-${var.kubernetes_version}*"
     }
@@ -182,9 +222,6 @@ usage: |-
   Module usage with two worker groups:
 
   ```hcl
-    {
-    ...
-
     module "eks_workers" {
       source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
       namespace                          = var.namespace
@@ -250,7 +287,46 @@ usage: |-
 
       workers_role_arns          = [module.eks_workers.workers_role_arn, module.eks_workers_2.workers_role_arn]
       workers_security_group_ids = [module.eks_workers.security_group_id, module.eks_workers_2.security_group_id]
-      
+    }
+  ```
+
+  Module usage on [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html):
+
+  ```hcl
+    provider "aws" {
+      region = "us-east-2"
+
+      assume_role {
+        role_arn = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+      }
+    }
+
+    module "eks_cluster" {
+      source                 = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+      namespace              = var.namespace
+      stage                  = var.stage
+      name                   = var.name
+      attributes             = var.attributes
+      tags                   = var.tags
+      region                 = "us-east-2"
+      vpc_id                 = module.vpc.vpc_id
+      subnet_ids             = module.subnets.public_subnet_ids
+
+      local_exec_interpreter = "/bin/bash"
+      kubernetes_version     = "1.14"
+
+      workers_role_arns          = [module.eks_workers.workers_role_arn]
+      workers_security_group_ids = [module.eks_workers.security_group_id]
+
+      # Terraform Cloud configurations
+      kubeconfig_path                                = "~/.kube/config"
+      configmap_auth_file                            = "/home/terraform/.terraform/configmap-auth.yaml"
+      install_aws_cli                                = true
+      install_kubectl                                = true
+      external_packages_install_path                 = "~/.terraform/bin"
+      aws_eks_update_kubeconfig_additional_arguments = "--verbose"
+      aws_cli_assume_role_arn                        = "arn:aws:iam::xxxxxxxxxxx:role/OrganizationAccountAccessRole"
+      aws_cli_assume_role_session_name               = "eks_cluster_example_session"
     }
   ```
 

--- a/auth.tf
+++ b/auth.tf
@@ -123,11 +123,11 @@ resource "null_resource" "apply_configmap_auth" {
           which kubectl
       fi
 
-      echo 'Applying ConfigMap...'
-      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path}
+      echo 'Applying configmap...'
+      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
       kubectl version --kubeconfig ${var.kubeconfig_path}
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
-      echo 'Applied ConfigMap'
+      echo 'Applied configmap'
     EOT
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -103,6 +103,8 @@ resource "null_resource" "apply_configmap_auth" {
           ./awscli-bundle/install -i ${local.external_packages_install_path}
           export PATH=$PATH:${local.external_packages_install_path}
           echo 'Installed AWS CLI'
+          which aws
+          aws --version
       fi
 
       install_kubectl=${var.install_kubectl}
@@ -114,11 +116,14 @@ resource "null_resource" "apply_configmap_auth" {
           chmod +x ./kubectl
           export PATH=$PATH:${local.external_packages_install_path}
           echo 'Installed kubectl'
+          which kubectl
+          kubectl version
       fi
 
-      while [[ ! -e ${local.configmap_auth_file} ]] ; do sleep 1; done && \
-      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} && \
+      echo 'Applying ConfigMap...'
+      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path}
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
+      echo 'Applied ConfigMap'
     EOT
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -95,6 +95,8 @@ resource "null_resource" "apply_configmap_auth" {
     interpreter = [var.local_exec_interpreter, "-c"]
 
     command = <<EOT
+      set -e
+
       install_aws_cli=${var.install_aws_cli}
       if [[ "$install_aws_cli" = true ]] ; then
           echo 'Installing AWS CLI...'
@@ -133,11 +135,11 @@ resource "null_resource" "apply_configmap_auth" {
         echo 'Assumed role ${var.aws_cli_assume_role_arn}'
       fi
 
-      echo 'Applying configmap...'
-      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments} && \
-      kubectl version --kubeconfig ${var.kubeconfig_path} && \
-      kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path} && \
-      echo 'Applied configmap'
+      echo 'Applying Auth configmap with kubectl...'
+      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
+      kubectl version --kubeconfig ${var.kubeconfig_path}
+      kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
+      echo 'Applied Auth configmap with kubectl'
     EOT
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -128,9 +128,9 @@ resource "null_resource" "apply_configmap_auth" {
       if [[ -n "$aws_cli_assume_role_arn" && -n "$aws_cli_assume_role_session_name" ]] ; then
         mkdir -p ${local.external_packages_install_path}
         cd ${local.external_packages_install_path}
-        curl -o jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
         chmod +x ./jq
-        source <(aws sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"  | jq -r  '.Credentials | @sh "export AWS_SESSION_TOKEN=\(.SessionToken)\nexport AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey) "')
+        source <(aws --output json sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"  | jq -r  '.Credentials | @sh "export AWS_SESSION_TOKEN=\(.SessionToken)\nexport AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey) "')
         #aws sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"
       fi
 

--- a/auth.tf
+++ b/auth.tf
@@ -124,13 +124,13 @@ resource "null_resource" "apply_configmap_auth" {
       aws_cli_assume_role_arn=${var.aws_cli_assume_role_arn}
       aws_cli_assume_role_session_name=${var.aws_cli_assume_role_session_name}
       if [[ -n "$aws_cli_assume_role_arn" && -n "$aws_cli_assume_role_session_name" ]] ; then
-        echo 'Assuming role "$aws_cli_assume_role_arn" ...'
+        echo 'Assuming role ${var.aws_cli_assume_role_arn} ...'
         mkdir -p ${local.external_packages_install_path}
         cd ${local.external_packages_install_path}
         curl -L https://github.com/stedolan/jq/releases/download/jq-${var.jq_version}/jq-linux64 -o jq
         chmod +x ./jq
         source <(aws --output json sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"  | jq -r  '.Credentials | @sh "export AWS_SESSION_TOKEN=\(.SessionToken)\nexport AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey) "')
-        echo 'Assumed role "$aws_cli_assume_role_arn"'
+        echo 'Assumed role ${var.aws_cli_assume_role_arn}'
       fi
 
       echo 'Applying configmap...'

--- a/auth.tf
+++ b/auth.tf
@@ -121,26 +121,23 @@ resource "null_resource" "apply_configmap_auth" {
           which kubectl
       fi
 
-      echo 'Applying configmap...'
-
       aws_cli_assume_role_arn=${var.aws_cli_assume_role_arn}
       aws_cli_assume_role_session_name=${var.aws_cli_assume_role_session_name}
       if [[ -n "$aws_cli_assume_role_arn" && -n "$aws_cli_assume_role_session_name" ]] ; then
+        echo 'Assuming role "$aws_cli_assume_role_arn" ...'
         mkdir -p ${local.external_packages_install_path}
         cd ${local.external_packages_install_path}
-        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq
+        curl -L https://github.com/stedolan/jq/releases/download/jq-${var.jq_version}/jq-linux64 -o jq
         chmod +x ./jq
         source <(aws --output json sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"  | jq -r  '.Credentials | @sh "export AWS_SESSION_TOKEN=\(.SessionToken)\nexport AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey) "')
-        #aws sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"
+        echo 'Assumed role "$aws_cli_assume_role_arn"'
       fi
 
+      echo 'Applying configmap...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments} && \
       kubectl version --kubeconfig ${var.kubeconfig_path} && \
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path} && \
       echo 'Applied configmap'
-
-      kubectl get nodes --kubeconfig ${var.kubeconfig_path}
-      kubectl get pods --all-namespaces --kubeconfig ${var.kubeconfig_path}
     EOT
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -101,7 +101,7 @@ resource "null_resource" "apply_configmap_auth" {
           curl -LO https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
           unzip ./awscli-bundle.zip
           ./awscli-bundle/install -i ${local.external_packages_install_path}
-          export PATH=$PATH:${local.external_packages_install_path}
+          export PATH=$PATH:${local.external_packages_install_path}:${local.external_packages_install_path}/bin
           echo 'Installed AWS CLI'
           which aws
           aws --version
@@ -117,11 +117,11 @@ resource "null_resource" "apply_configmap_auth" {
           export PATH=$PATH:${local.external_packages_install_path}
           echo 'Installed kubectl'
           which kubectl
-          kubectl version
       fi
 
       echo 'Applying ConfigMap...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path}
+      kubectl version --kubeconfig ${var.kubeconfig_path}
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
       echo 'Applied ConfigMap'
     EOT

--- a/auth.tf
+++ b/auth.tf
@@ -80,11 +80,13 @@ resource "null_resource" "apply_configmap_auth" {
   count = var.enabled && var.apply_config_map_aws_auth ? 1 : 0
 
   triggers = {
-    cluster_updated                 = join("", aws_eks_cluster.default.*.id)
-    worker_roles_updated            = local.map_worker_roles_yaml
-    additional_roles_updated        = local.map_additional_iam_roles_yaml
-    additional_users_updated        = local.map_additional_iam_users_yaml
-    additional_aws_accounts_updated = local.map_additional_aws_accounts_yaml
+    cluster_updated                     = join("", aws_eks_cluster.default.*.id)
+    worker_roles_updated                = local.map_worker_roles_yaml
+    additional_roles_updated            = local.map_additional_iam_roles_yaml
+    additional_users_updated            = local.map_additional_iam_users_yaml
+    additional_aws_accounts_updated     = local.map_additional_aws_accounts_yaml
+    configmap_auth_file_content_changed = join("", local_file.configmap_auth.*.content)
+    configmap_auth_file_id_changed      = join("", local_file.configmap_auth.*.id)
   }
 
   depends_on = [aws_eks_cluster.default, local_file.configmap_auth]
@@ -94,6 +96,7 @@ resource "null_resource" "apply_configmap_auth" {
 
     command = <<EOT
       install_aws_cli=${var.install_aws_cli}
+
       if [[ "$install_aws_cli" = true ]] ; then
           echo 'Installing AWS CLI...'
           mkdir -p ${local.external_packages_install_path}
@@ -108,6 +111,7 @@ resource "null_resource" "apply_configmap_auth" {
       fi
 
       install_kubectl=${var.install_kubectl}
+
       if [[ "$install_kubectl" = true ]] ; then
           echo 'Installing kubectl...'
           mkdir -p ${local.external_packages_install_path}

--- a/auth.tf
+++ b/auth.tf
@@ -97,22 +97,23 @@ resource "null_resource" "apply_configmap_auth" {
       if [[ "$install_aws_cli" = true ]] ; then
           echo 'Installing AWS CLI...'
           mkdir -p ${local.external_packages_install_path}
-          curl -LO https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o ${local.external_packages_install_path}/awscli-bundle.zip
           cd ${local.external_packages_install_path}
-          unzip awscli-bundle.zip
+          curl -LO https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+          unzip ./awscli-bundle.zip
           ./awscli-bundle/install -i ${local.external_packages_install_path}
           export PATH=$PATH:${local.external_packages_install_path}
+          echo 'Installed AWS CLI'
       fi
 
       install_kubectl=${var.install_kubectl}
       if [[ "$install_kubectl" = true ]] ; then
           echo 'Installing kubectl...'
           mkdir -p ${local.external_packages_install_path}
-          kubectl_version=${local.kubectl_version}
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/"$kubectl_version"/bin/linux/amd64/kubectl -o ${local.external_packages_install_path}
           cd ${local.external_packages_install_path}
-          chmod +x kubectl
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/${local.kubectl_version}/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
           export PATH=$PATH:${local.external_packages_install_path}
+          echo 'Installed kubectl'
       fi
 
       while [[ ! -e ${local.configmap_auth_file} ]] ; do sleep 1; done && \

--- a/auth.tf
+++ b/auth.tf
@@ -93,15 +93,10 @@ resource "null_resource" "apply_configmap_auth" {
     interpreter = [var.local_exec_interpreter, "-c"]
 
     command = <<EOT
-      # https://www.terraform.io/docs/cloud/run/install-software.html
-      # https://stackoverflow.com/questions/26123740/is-it-possible-to-install-aws-cli-package-without-root-permission
-      # https://stackoverflow.com/questions/58232731/kubectl-missing-form-terraform-cloud
-      # https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html
-      # https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html
-
-      install_aws_cli = ${var.install_aws_cli}
+      install_aws_cli=${var.install_aws_cli}
       if [[ "$install_aws_cli" = true ]] ; then
           echo 'Installing AWS CLI...'
+          mkdir -p ${local.external_packages_install_path}
           curl -LO https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o ${local.external_packages_install_path}/awscli-bundle.zip
           cd ${local.external_packages_install_path}
           unzip awscli-bundle.zip
@@ -109,10 +104,11 @@ resource "null_resource" "apply_configmap_auth" {
           export PATH=$PATH:${local.external_packages_install_path}
       fi
 
-      install_kubectl = ${var.install_kubectl}
+      install_kubectl=${var.install_kubectl}
       if [[ "$install_kubectl" = true ]] ; then
           echo 'Installing kubectl...'
-          kubectl_version = ${local.kubectl_version}
+          mkdir -p ${local.external_packages_install_path}
+          kubectl_version=${local.kubectl_version}
           curl -LO https://storage.googleapis.com/kubernetes-release/release/"$kubectl_version"/bin/linux/amd64/kubectl -o ${local.external_packages_install_path}
           cd ${local.external_packages_install_path}
           chmod +x kubectl

--- a/auth.tf
+++ b/auth.tf
@@ -134,10 +134,9 @@ resource "null_resource" "apply_configmap_auth" {
         #aws sts assume-role --role-arn "$aws_cli_assume_role_arn" --role-session-name "$aws_cli_assume_role_session_name"
       fi
 
-      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
-      kubectl version --kubeconfig ${var.kubeconfig_path}
-      kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
-
+      aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments} && \
+      kubectl version --kubeconfig ${var.kubeconfig_path} && \
+      kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path} && \
       echo 'Applied configmap'
     EOT
   }

--- a/auth.tf
+++ b/auth.tf
@@ -135,11 +135,11 @@ resource "null_resource" "apply_configmap_auth" {
         echo 'Assumed role ${var.aws_cli_assume_role_arn}'
       fi
 
-      echo 'Applying Auth configmap with kubectl...'
+      echo 'Applying Auth ConfigMap with kubectl...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
       kubectl version --kubeconfig ${var.kubeconfig_path}
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
-      echo 'Applied Auth configmap with kubectl'
+      echo 'Applied Auth ConfigMap with kubectl'
     EOT
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -138,6 +138,9 @@ resource "null_resource" "apply_configmap_auth" {
       kubectl version --kubeconfig ${var.kubeconfig_path} && \
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path} && \
       echo 'Applied configmap'
+
+      kubectl get nodes --kubeconfig ${var.kubeconfig_path}
+      kubectl get pods --all-namespaces --kubeconfig ${var.kubeconfig_path}
     EOT
   }
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 | external_packages_install_path | Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers | string | `` | no |
 | install_aws_cli | Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
 | install_kubectl | Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
+| jq_version | Version of `jq` to download to extract temporaly credentials after running `aws sts assume-role` if AWS CLI needs to assume role to access the cluster (if variable `aws_cli_assume_role_arn` is set) | string | `1.6` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,7 @@
 | apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,7 +24,7 @@
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
 | kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
-| local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
+| local_exec_interpreter | shell to use for local exec | string | `/bin/bash` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |
 | map_additional_iam_roles | Additional IAM roles to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,8 @@
 | apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |
+| aws_cli_assume_role_session_name | An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,7 +14,11 @@
 | enabled_cluster_log_types | A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`] | list(string) | `<list>` | no |
 | endpoint_private_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. Default to AWS EKS resource and it is false | bool | `false` | no |
 | endpoint_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true | bool | `true` | no |
+| external_packages_install_path | Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers | string | `` | no |
+| install_aws_cli | Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
+| install_kubectl | Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers | bool | `false` | no |
 | kubeconfig_path | The path to `kubeconfig` file | string | `~/.kube/config` | no |
+| kubectl_version | `kubectl` version to install. If not specified, the latest version will be used | string | `` | no |
 | kubernetes_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | string | `1.14` | no |
 | local_exec_interpreter | shell to use for local exec | string | `/bin/sh` | no |
 | map_additional_aws_accounts | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap | list(string) | `<list>` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -96,6 +96,8 @@ module "eks_cluster" {
   kubectl_version                                = var.kubectl_version
   external_packages_install_path                 = var.external_packages_install_path
   aws_eks_update_kubeconfig_additional_arguments = var.aws_eks_update_kubeconfig_additional_arguments
+  aws_cli_assume_role_arn                        = var.aws_cli_assume_role_arn
+  aws_cli_assume_role_session_name               = var.aws_cli_assume_role_session_name
 
   workers_role_arns          = [module.eks_workers.workers_role_arn]
   workers_security_group_ids = [module.eks_workers.security_group_id]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -97,6 +97,7 @@ module "eks_cluster" {
   install_aws_cli                                = var.install_aws_cli
   install_kubectl                                = var.install_kubectl
   kubectl_version                                = var.kubectl_version
+  jq_version                                     = var.jq_version
   external_packages_install_path                 = var.external_packages_install_path
   aws_eks_update_kubeconfig_additional_arguments = var.aws_eks_update_kubeconfig_additional_arguments
   aws_cli_assume_role_arn                        = var.aws_cli_assume_role_arn

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -79,17 +79,18 @@ module "eks_workers" {
 }
 
 module "eks_cluster" {
-  source             = "../../"
-  namespace          = var.namespace
-  stage              = var.stage
-  name               = var.name
-  attributes         = var.attributes
-  tags               = var.tags
-  region             = var.region
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.subnets.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  kubeconfig_path    = var.kubeconfig_path
+  source                 = "../../"
+  namespace              = var.namespace
+  stage                  = var.stage
+  name                   = var.name
+  attributes             = var.attributes
+  tags                   = var.tags
+  region                 = var.region
+  vpc_id                 = module.vpc.vpc_id
+  subnet_ids             = module.subnets.public_subnet_ids
+  kubernetes_version     = var.kubernetes_version
+  kubeconfig_path        = var.kubeconfig_path
+  local_exec_interpreter = var.local_exec_interpreter
 
   configmap_auth_template_file = var.configmap_auth_template_file
   configmap_auth_file          = var.configmap_auth_file

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -79,21 +79,23 @@ module "eks_workers" {
 }
 
 module "eks_cluster" {
-  source                         = "../../"
-  namespace                      = var.namespace
-  stage                          = var.stage
-  name                           = var.name
-  attributes                     = var.attributes
-  tags                           = var.tags
-  region                         = var.region
-  vpc_id                         = module.vpc.vpc_id
-  subnet_ids                     = module.subnets.public_subnet_ids
-  kubernetes_version             = var.kubernetes_version
-  kubeconfig_path                = var.kubeconfig_path
-  install_aws_cli                = var.install_aws_cli
-  install_kubectl                = var.install_kubectl
-  kubectl_version                = var.kubectl_version
-  external_packages_install_path = var.external_packages_install_path
+  source             = "../../"
+  namespace          = var.namespace
+  stage              = var.stage
+  name               = var.name
+  attributes         = var.attributes
+  tags               = var.tags
+  region             = var.region
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.subnets.public_subnet_ids
+  kubernetes_version = var.kubernetes_version
+  kubeconfig_path    = var.kubeconfig_path
+  install_aws_cli    = var.install_aws_cli
+
+  install_kubectl                                = var.install_kubectl
+  kubectl_version                                = var.kubectl_version
+  external_packages_install_path                 = var.external_packages_install_path
+  aws_eks_update_kubeconfig_additional_arguments = var.aws_eks_update_kubeconfig_additional_arguments
 
   workers_role_arns          = [module.eks_workers.workers_role_arn]
   workers_security_group_ids = [module.eks_workers.security_group_id]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -90,8 +90,11 @@ module "eks_cluster" {
   subnet_ids         = module.subnets.public_subnet_ids
   kubernetes_version = var.kubernetes_version
   kubeconfig_path    = var.kubeconfig_path
-  install_aws_cli    = var.install_aws_cli
 
+  configmap_auth_template_file = var.configmap_auth_template_file
+  configmap_auth_file          = var.configmap_auth_file
+
+  install_aws_cli                                = var.install_aws_cli
   install_kubectl                                = var.install_kubectl
   kubectl_version                                = var.kubectl_version
   external_packages_install_path                 = var.external_packages_install_path

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -27,7 +27,7 @@ locals {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -37,7 +37,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -52,7 +52,7 @@ module "subnets" {
 }
 
 module "eks_workers" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=tags/0.10.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=tags/0.11.0"
   namespace                          = var.namespace
   stage                              = var.stage
   name                               = var.name
@@ -79,17 +79,21 @@ module "eks_workers" {
 }
 
 module "eks_cluster" {
-  source             = "../../"
-  namespace          = var.namespace
-  stage              = var.stage
-  name               = var.name
-  attributes         = var.attributes
-  tags               = var.tags
-  region             = var.region
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.subnets.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  kubeconfig_path    = var.kubeconfig_path
+  source                         = "../../"
+  namespace                      = var.namespace
+  stage                          = var.stage
+  name                           = var.name
+  attributes                     = var.attributes
+  tags                           = var.tags
+  region                         = var.region
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.subnets.public_subnet_ids
+  kubernetes_version             = var.kubernetes_version
+  kubeconfig_path                = var.kubeconfig_path
+  install_aws_cli                = var.install_aws_cli
+  install_kubectl                = var.install_kubectl
+  kubectl_version                = var.kubectl_version
+  external_packages_install_path = var.external_packages_install_path
 
   workers_role_arns          = [module.eks_workers.workers_role_arn]
   workers_security_group_ids = [module.eks_workers.security_group_id]

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -180,3 +180,9 @@ variable "aws_cli_assume_role_session_name" {
   default     = ""
   description = "An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig`"
 }
+
+variable "jq_version" {
+  type        = string
+  default     = "1.6"
+  description = "Version of `jq` to download to extract temporaly credentials after running `aws sts assume-role` if AWS CLI needs to assume role to access the cluster (if variable `aws_cli_assume_role_arn` is set)"
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -126,3 +126,27 @@ variable "kubeconfig_path" {
   type        = string
   description = "The path to `kubeconfig` file"
 }
+
+variable "install_aws_cli" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers"
+}
+
+variable "install_kubectl" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers"
+}
+
+variable "kubectl_version" {
+  type        = string
+  default     = ""
+  description = "`kubectl` version to install. If not specified, the latest version will be used"
+}
+
+variable "external_packages_install_path" {
+  type        = string
+  default     = ""
+  description = "Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers"
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -150,3 +150,9 @@ variable "external_packages_install_path" {
   default     = ""
   description = "Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers"
 }
+
+variable "aws_eks_update_kubeconfig_additional_arguments" {
+  type        = string
+  default     = ""
+  description = "Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html"
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -127,6 +127,12 @@ variable "kubeconfig_path" {
   description = "The path to `kubeconfig` file"
 }
 
+variable "local_exec_interpreter" {
+  type        = string
+  default     = "/bin/bash"
+  description = "shell to use for local exec"
+}
+
 variable "configmap_auth_template_file" {
   type        = string
   default     = ""

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -127,6 +127,18 @@ variable "kubeconfig_path" {
   description = "The path to `kubeconfig` file"
 }
 
+variable "configmap_auth_template_file" {
+  type        = string
+  default     = ""
+  description = "Path to `config_auth_template_file`"
+}
+
+variable "configmap_auth_file" {
+  type        = string
+  default     = ""
+  description = "Path to `configmap_auth_file`"
+}
+
 variable "install_aws_cli" {
   type        = bool
   default     = false

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -156,3 +156,15 @@ variable "aws_eks_update_kubeconfig_additional_arguments" {
   default     = ""
   description = "Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html"
 }
+
+variable "aws_cli_assume_role_arn" {
+  type        = string
+  default     = ""
+  description = "IAM Role ARN for AWS CLI to assume before calling `aws eks` to update kubeconfig"
+}
+
+variable "aws_cli_assume_role_session_name" {
+  type        = string
+  default     = ""
+  description = "An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig`"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -207,3 +207,9 @@ variable "aws_cli_assume_role_session_name" {
   default     = ""
   description = "An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig`"
 }
+
+variable "jq_version" {
+  type        = string
+  default     = "1.6"
+  description = "Version of `jq` to download to extract temporaly credentials after running `aws sts assume-role` if AWS CLI needs to assume role to access the cluster (if variable `aws_cli_assume_role_arn` is set)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -150,7 +150,7 @@ variable "kubeconfig_path" {
 
 variable "local_exec_interpreter" {
   type        = string
-  default     = "/bin/sh"
+  default     = "/bin/bash"
   description = "shell to use for local exec"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -195,3 +195,15 @@ variable "aws_eks_update_kubeconfig_additional_arguments" {
   default     = ""
   description = "Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html"
 }
+
+variable "aws_cli_assume_role_arn" {
+  type        = string
+  default     = ""
+  description = "IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig`"
+}
+
+variable "aws_cli_assume_role_session_name" {
+  type        = string
+  default     = ""
+  description = "An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig`"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,27 @@ variable "configmap_auth_file" {
   default     = ""
   description = "Path to `configmap_auth_file`"
 }
+
+variable "install_aws_cli" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to install AWS CLI if the module is provisioned on workstations where AWS CLI is not installed by default, e.g. Terraform Cloud workers"
+}
+
+variable "install_kubectl" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to install `kubectl` if the module is provisioned on workstations where `kubectl` is not installed by default, e.g. Terraform Cloud workers"
+}
+
+variable "kubectl_version" {
+  type        = string
+  default     = ""
+  description = "`kubectl` version to install. If not specified, the latest version will be used"
+}
+
+variable "external_packages_install_path" {
+  type        = string
+  default     = ""
+  description = "Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -189,3 +189,9 @@ variable "external_packages_install_path" {
   default     = ""
   description = "Path to install external packages, e.g. AWS CLI and `kubectl`. Used when the module is provisioned on workstations where the external packages are not installed by default, e.g. Terraform Cloud workers"
 }
+
+variable "aws_eks_update_kubeconfig_additional_arguments" {
+  type        = string
+  default     = ""
+  description = "Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html"
+}


### PR DESCRIPTION
## what
* Update provisioner "local-exec":
  - Optionally install external packages (AWS CLI and `kubectl`) if the worstation that runs `terraform plan/apply` does not have them installed
  - Optionally assume IAM role before executing the command `aws eks update-kubeconfig`

## why
* Installing external packages allows the module to be provisioned on Terraform Cloud where the workers are running on plain Ubuntu without having AWS CLI and `kubectl` installed
* Assuming IAM role before executing the command `aws eks update-kubeconfig` allows the module to be provisioned on Terraform Cloud in multi-account setup, where we provide TF Cloud with the IAM User access keys from the identity account and allow it to assume an IAM Role into the AWS account where the module gets provisioned
