### PR TITLE
Add OIDC Issuer to module output

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Available targets:
 | eks_cluster_certificate_authority_data | The Kubernetes cluster certificate authority data |
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
+| eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -46,6 +46,7 @@
 | eks_cluster_certificate_authority_data | The Kubernetes cluster certificate authority data |
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
+| eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -48,6 +48,11 @@ output "eks_cluster_version" {
   value       = module.eks_cluster.eks_cluster_version
 }
 
+output "eks_cluster_identity_oidc_issuer" {
+  description = "The OIDC Identity issuer for the cluster"
+  value       = module.eks_cluster.eks_cluster_identity_oidc_issuer
+}
+
 output "workers_launch_template_id" {
   description = "ID of the launch template"
   value       = module.eks_workers.launch_template_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "eks_cluster_version" {
   value       = join("", aws_eks_cluster.default.*.version)
 }
 
+output "eks_cluster_identity_oidc_issuer" {
+  description = "The OIDC Identity issuer for the cluster"
+  value       = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+}
+
 output "eks_cluster_certificate_authority_data" {
   description = "The Kubernetes cluster certificate authority data"
   value       = local.certificate_authority_data


### PR DESCRIPTION
Add the OIDC Provider output to the module, to enable module consumers to link IAM roles to service accounts, as described [here](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).

Note, updating the readme seemed to fail on MacOS, so not updated yet.