### PR TITLE
feat(oidc-provider): Add oidc_provider_enabled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Available targets:
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
-| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts |
+| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Other examples:
     kubernetes_version = var.kubernetes_version
     kubeconfig_path    = var.kubeconfig_path
 
+    oidc_provider_enabled = false
+
     workers_security_group_ids   = [module.eks_workers.security_group_id]
     workers_role_arns            = [module.eks_workers.workers_role_arn]
   }
@@ -304,6 +306,8 @@ Module usage with two worker groups:
 
     kubernetes_version = var.kubernetes_version
     kubeconfig_path    = var.kubeconfig_path
+
+    oidc_provider_enabled = false
 
     workers_role_arns          = [module.eks_workers.workers_role_arn, module.eks_workers_2.workers_role_arn]
     workers_security_group_ids = [module.eks_workers.security_group_id, module.eks_workers_2.security_group_id]
@@ -397,6 +401,7 @@ Available targets:
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
+| oidc_provider_enabled | Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html | bool | `false` | no |
 | region | AWS Region | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_ids | A list of subnet IDs to launch the cluster in | list(string) | - | yes |
@@ -414,6 +419,7 @@ Available targets:
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
+| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/README.yaml
+++ b/README.yaml
@@ -214,6 +214,8 @@ usage: |-
       kubernetes_version = var.kubernetes_version
       kubeconfig_path    = var.kubeconfig_path
 
+      oidc_provider_enabled = false
+
       workers_security_group_ids   = [module.eks_workers.security_group_id]
       workers_role_arns            = [module.eks_workers.workers_role_arn]
     }
@@ -284,6 +286,8 @@ usage: |-
 
       kubernetes_version = var.kubernetes_version
       kubeconfig_path    = var.kubeconfig_path
+
+      oidc_provider_enabled = false
 
       workers_role_arns          = [module.eks_workers.workers_role_arn, module.eks_workers_2.workers_role_arn]
       workers_security_group_ids = [module.eks_workers.security_group_id, module.eks_workers_2.security_group_id]

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -48,7 +48,7 @@
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
-| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts |
+| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,7 @@
 | map_additional_iam_users | Additional IAM users to add to `config-map-aws-auth` ConfigMap | object | `<list>` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | `` | no |
+| oidc_provider_enabled | Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html | bool | `false` | no |
 | region | AWS Region | string | - | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `` | no |
 | subnet_ids | A list of subnet IDs to launch the cluster in | list(string) | - | yes |
@@ -47,6 +48,7 @@
 | eks_cluster_endpoint | The endpoint for the Kubernetes API server |
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
+| eks_cluster_identity_oidc_issuer_arn | The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -29,3 +29,5 @@ associate_public_ip_address = true
 kubernetes_version = "1.14"
 
 kubeconfig_path = "/.kube/config"
+
+oidc_provider_enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,6 +94,7 @@ module "eks_cluster" {
 
   configmap_auth_template_file = var.configmap_auth_template_file
   configmap_auth_file          = var.configmap_auth_file
+  oidc_provider_enabled        = var.oidc_provider_enabled
 
   install_aws_cli                                = var.install_aws_cli
   install_kubectl                                = var.install_kubectl

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -122,6 +122,12 @@ variable "map_additional_iam_users" {
   default = []
 }
 
+variable "oidc_provider_enabled" {
+  type        = bool
+  default     = false
+  description = "Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html"
+}
+
 variable "kubeconfig_path" {
   type        = string
   description = "The path to `kubeconfig` file"

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_eks_cluster" "default" {
   ]
 }
 
-# Enabling IAM Roles for Service Accounts on your Cluster
+# Enabling IAM Roles for Service Accounts in Kubernetes cluster
 #
 # From official docs:
 # The IAM roles for service accounts feature is available on new Amazon EKS Kubernetes version 1.14 clusters,

--- a/main.tf
+++ b/main.tf
@@ -113,3 +113,22 @@ resource "aws_eks_cluster" "default" {
     aws_iam_role_policy_attachment.amazon_eks_service_policy
   ]
 }
+
+# Enabling IAM Roles for Service Accounts on your Cluster
+#
+# From official docs:
+# The IAM roles for service accounts feature is available on new Amazon EKS Kubernetes version 1.14 clusters,
+# and clusters that were updated to versions 1.14 or 1.13 on or after September 3rd, 2019.
+#
+# https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+# https://medium.com/@marcincuber/amazon-eks-with-oidc-provider-iam-roles-for-kubernetes-services-accounts-59015d15cb0c
+#
+resource "aws_iam_openid_connect_provider" "default" {
+  count = (var.enabled && var.oidc_provider_enabled) ? 1 : 0
+  url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+
+  client_id_list = ["sts.amazonaws.com"]
+  # it's thumbprint won't change for many years :)
+  # https://github.com/terraform-providers/terraform-provider-aws/issues/10104
+  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,7 +39,7 @@ output "eks_cluster_identity_oidc_issuer" {
 }
 
 output "eks_cluster_identity_oidc_issuer_arn" {
-  description = "The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts"
+  description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
   value       = join("", aws_iam_openid_connect_provider.default.*.arn)
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,6 +38,11 @@ output "eks_cluster_identity_oidc_issuer" {
   value       = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
 }
 
+output "eks_cluster_identity_oidc_issuer_arn" {
+  description = "The OIDC Identity ARN issuer for the cluster, that can be used to associate IAM roles with a service accounts"
+  value       = join("", aws_iam_openid_connect_provider.default.*.arn)
+}
+
 output "eks_cluster_certificate_authority_data" {
   description = "The Kubernetes cluster certificate authority data"
   value       = local.certificate_authority_data

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "kubernetes_version" {
   description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used"
 }
 
+variable "oidc_provider_enabled" {
+  type        = bool
+  default     = false
+  description = "Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html"
+}
+
 variable "endpoint_private_access" {
   type        = bool
   default     = false


### PR DESCRIPTION
**what**

Added oidc_provider_enabled variable in order to create an IAM OIDC identity provider for the cluster,
then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam.

For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html

**why**

For better developer experience would be nice to have an opputunity to create an **aws_iam_openid_connect_provider** resource inside the module,  cause **terraform-aws-provider** does not support **aws_iam_openid_connect_provider** as a data source.