### PR TITLE
Add configurable retention period for cluster logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Available targets:
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_cli_assume_role_session_name | An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
+| cluster_log_retention_period | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | number | `0` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,6 +10,7 @@
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_cli_assume_role_session_name | An identifier for the assumed role session when assuming the IAM Role for AWS CLI before calling `aws eks` to update `kubeconfig` | string | `` | no |
 | aws_eks_update_kubeconfig_additional_arguments | Additional arguments for `aws eks update-kubeconfig` command, e.g. `--role-arn xxxxxxxxx`. For more info, see https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html | string | `` | no |
+| cluster_log_retention_period | Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. | number | `0` | no |
 | configmap_auth_file | Path to `configmap_auth_file` | string | `` | no |
 | configmap_auth_template_file | Path to `config_auth_template_file` | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -31,3 +31,7 @@ kubernetes_version = "1.14"
 kubeconfig_path = "/.kube/config"
 
 oidc_provider_enabled = true
+
+enabled_cluster_log_types = ["audit"]
+
+cluster_log_retention_period = 7

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -105,6 +105,9 @@ module "eks_cluster" {
   aws_cli_assume_role_arn                        = var.aws_cli_assume_role_arn
   aws_cli_assume_role_session_name               = var.aws_cli_assume_role_session_name
 
+  enabled_cluster_log_types    = var.enabled_cluster_log_types
+  cluster_log_retention_period = var.cluster_log_retention_period
+
   workers_role_arns          = [module.eks_workers.workers_role_arn]
   workers_security_group_ids = [module.eks_workers.security_group_id]
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -92,6 +92,18 @@ variable "cpu_utilization_low_threshold_percent" {
   description = "Worker nodes AutoScaling Group CPU utilization low threshold percent"
 }
 
+variable "enabled_cluster_log_types" {
+  type        = list(string)
+  default     = []
+  description = "A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`]"
+}
+
+variable "cluster_log_retention_period" {
+  type        = number
+  default     = 0
+  description = "Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html."
+}
+
 variable "map_additional_aws_accounts" {
   description = "Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap"
   type        = list(string)

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 resource "aws_cloudwatch_log_group" "default" {
-  count             = var.enabled && length(var.enabled_cluster_log_types) ? 1 : 0
+  count             = var.enabled && length(var.enabled_cluster_log_types) > 0 ? 1 : 0
   name              = "/aws/eks/${module.label.id}/cluster"
   retention_in_days = var.cluster_log_retention_period
   tags              = module.label.tags

--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,13 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
   type              = "ingress"
 }
 
+resource "aws_cloudwatch_log_group" "default" {
+  count             = var.enabled && length(var.enabled_cluster_log_types) ? 1 : 0
+  name              = "/aws/eks/${module.label.id}/cluster"
+  retention_in_days = var.cluster_log_retention_period
+  tags              = module.label.tags
+}
+
 resource "aws_eks_cluster" "default" {
   count                     = var.enabled ? 1 : 0
   name                      = module.label.id
@@ -110,7 +117,8 @@ resource "aws_eks_cluster" "default" {
 
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_cluster_policy,
-    aws_iam_role_policy_attachment.amazon_eks_service_policy
+    aws_iam_role_policy_attachment.amazon_eks_service_policy,
+    aws_cloudwatch_log_group.default
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,12 @@ variable "enabled_cluster_log_types" {
   description = "A list of the desired control plane logging to enable. For more information, see https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html. Possible values [`api`, `audit`, `authenticator`, `controllerManager`, `scheduler`]"
 }
 
+variable "cluster_log_retention_period" {
+  type        = number
+  default     = 0
+  description = "Number of days to retain cluster logs. Requires `enabled_cluster_log_types` to be set. See https://docs.aws.amazon.com/en_us/eks/latest/userguide/control-plane-logs.html."
+}
+
 variable "apply_config_map_aws_auth" {
   type        = bool
   default     = true


### PR DESCRIPTION
Per example in docs: https://www.terraform.io/docs/providers/aws/r/eks_cluster.html#enabling-control-plane-logging

Until `depends_on` is supported by modules, there can be a race
condition if `resource "aws_cloudwatch_log_group"` is called at the same
time as this `module`. This can result in the module creating the log
group first requiring a `terraform import ... ; terraform apply` dance.