### PR TITLE
terraform 0.12 compliance: unquote "string" type in variable def

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -53,7 +53,7 @@ variable "kubernetes_version" {
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 resource "aws_eks_cluster" "default" {
   count                     = var.enabled ? 1 : 0
   name                      = module.label.id
+  tags                      = module.label.tags
   role_arn                  = join("", aws_iam_role.default.*.arn)
   version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types


### PR DESCRIPTION
Probably this one just got missed in previous convert.