### PR TITLE
Auth wait for cluster

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -137,7 +137,7 @@ resource "null_resource" "apply_configmap_auth" {
 
       echo 'Applying Auth ConfigMap with kubectl...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
-      kubectl version --kubeconfig ${var.kubeconfig_path}
+      until kubectl version --kubeconfig ${var.kubeconfig_path} >/dev/null; do sleep 4; done
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
       echo 'Applied Auth ConfigMap with kubectl'
     EOT

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -53,7 +53,7 @@ variable "kubernetes_version" {
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 resource "aws_eks_cluster" "default" {
   count                     = var.enabled ? 1 : 0
   name                      = module.label.id
+  tags                      = module.label.tags
   role_arn                  = join("", aws_iam_role.default.*.arn)
   version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types


### PR DESCRIPTION
When setting up kubeconfig, wait for cluster to become interactive before trying to interact with it.

Also bumps subnet module version to avoid tf 0.12-related warnings