### PR TITLE
Fix variables. Add waiting for the cluster to be ready

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2019 Cloud Posse, LLC
+   Copyright 2018-2020 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
-| apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
+| apply_config_map_aws_auth | Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
-| apply_config_map_aws_auth | Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
+| apply_config_map_aws_auth | Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |

--- a/auth.tf
+++ b/auth.tf
@@ -137,7 +137,8 @@ resource "null_resource" "apply_configmap_auth" {
 
       echo 'Applying Auth ConfigMap with kubectl...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
-      kubectl version --kubeconfig ${var.kubeconfig_path}
+      command='kubectl version --kubeconfig ${var.kubeconfig_path}'
+      for i in $(seq 1 10); do command && s=0 && break || s=$? && sleep 5; done; (exit $s)
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
       echo 'Applied Auth ConfigMap with kubectl'
     EOT

--- a/auth.tf
+++ b/auth.tf
@@ -137,8 +137,8 @@ resource "null_resource" "apply_configmap_auth" {
 
       echo 'Applying Auth ConfigMap with kubectl...'
       aws eks update-kubeconfig --name=${local.cluster_name} --region=${var.region} --kubeconfig=${var.kubeconfig_path} ${var.aws_eks_update_kubeconfig_additional_arguments}
-      command='kubectl version --kubeconfig ${var.kubeconfig_path}'
-      for i in $(seq 1 10); do command && s=0 && break || s=$? && sleep 5; done; (exit $s)
+      until kubectl version --kubeconfig ${var.kubeconfig_path} >/dev/null; do sleep 5; done
+      kubectl version --kubeconfig ${var.kubeconfig_path}
       kubectl apply -f ${local.configmap_auth_file} --kubeconfig ${var.kubeconfig_path}
       echo 'Applied Auth ConfigMap with kubectl'
     EOT

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
-| apply_config_map_aws_auth | Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
+| apply_config_map_aws_auth | Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
 | allowed_security_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | list(string) | `<list>` | no |
-| apply_config_map_aws_auth | Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
+| apply_config_map_aws_auth | Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster | bool | `true` | no |
 | associate_public_ip_address | Associate a public IP address with an instance in a VPC | bool | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | aws_cli_assume_role_arn | IAM Role ARN for AWS CLI to assume before calling `aws eks` to update `kubeconfig` | string | `` | no |

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -53,7 +53,7 @@ variable "kubernetes_version" {
 }
 
 variable "health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
 }
 
@@ -125,7 +125,7 @@ variable "map_additional_iam_users" {
 variable "oidc_provider_enabled" {
   type        = bool
   default     = false
-  description = "Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using kiam or kube2iam. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html"
+  description = "Create an IAM OIDC identity provider for the cluster, then you can create IAM roles to associate with a service account in the cluster, instead of using `kiam` or `kube2iam`. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html"
 }
 
 variable "kubeconfig_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -122,7 +122,7 @@ variable "enabled_cluster_log_types" {
 variable "apply_config_map_aws_auth" {
   type        = bool
   default     = true
-  description = "Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster"
+  description = "Whether to execute `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster"
 }
 
 variable "map_additional_aws_accounts" {

--- a/variables.tf
+++ b/variables.tf
@@ -122,7 +122,7 @@ variable "enabled_cluster_log_types" {
 variable "apply_config_map_aws_auth" {
   type        = bool
   default     = true
-  description = "Whether to generate local files from `kubeconfig` and `config-map-aws-auth` templates and perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster"
+  description = "Whether to perform `kubectl apply` to apply the ConfigMap to allow worker nodes to join the EKS cluster"
 }
 
 variable "map_additional_aws_accounts" {


### PR DESCRIPTION
## what
* Fix variables
* Add waiting for the cluster to be ready before applying k8s auth map

## why
* Update variable descriptions and fix type
* In some cases, after the cluster gets provisioned with terraform, it's still not ready and `kubectl` fails. Try a few times with delay.

## related
* Closes #41 
* Closes #43 
* Closes #44 

