### PR TITLE
Add `eks_cluster_managed_security_group_id` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Available targets:
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
 | eks_cluster_identity_oidc_issuer_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account |
+| eks_cluster_managed_security_group_id | Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -52,6 +52,7 @@
 | eks_cluster_id | The name of the cluster |
 | eks_cluster_identity_oidc_issuer | The OIDC Identity issuer for the cluster |
 | eks_cluster_identity_oidc_issuer_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account |
+| eks_cluster_managed_security_group_id | Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads |
 | eks_cluster_version | The Kubernetes server version of the cluster |
 | security_group_arn | ARN of the EKS cluster Security Group |
 | security_group_id | ID of the EKS cluster Security Group |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,7 +37,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -52,7 +52,7 @@ module "subnets" {
 }
 
 module "eks_workers" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=tags/0.11.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=tags/0.12.0"
   namespace                          = var.namespace
   stage                              = var.stage
   name                               = var.name

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -132,3 +132,8 @@ output "workers_role_name" {
   description = "Name of the worker nodes IAM role"
   value       = module.eks_workers.workers_role_name
 }
+
+output "eks_cluster_managed_security_group_id" {
+  description = "Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads"
+  value       = module.eks_cluster.eks_cluster_managed_security_group_id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,5 +50,5 @@ output "eks_cluster_certificate_authority_data" {
 
 output "eks_cluster_managed_security_group_id" {
   description = "Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads"
-  value       = join("", aws_eks_cluster.default.*.vpc_config.cluster_security_group_id)
+  value       = aws_eks_cluster.default.0.vpc_config.cluster_security_group_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,5 +50,5 @@ output "eks_cluster_certificate_authority_data" {
 
 output "eks_cluster_managed_security_group_id" {
   description = "Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads"
-  value       = aws_eks_cluster.default.0.vpc_config.cluster_security_group_id
+  value       = join("", aws_eks_cluster.default.*.vpc_config.0.cluster_security_group_id)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,8 @@ output "eks_cluster_certificate_authority_data" {
   description = "The Kubernetes cluster certificate authority data"
   value       = local.certificate_authority_data
 }
+
+output "eks_cluster_managed_security_group_id" {
+  description = "Security Group ID that was created by EKS for the cluster. EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads"
+  value       = join("", aws_eks_cluster.default.*.vpc_config.cluster_security_group_id)
+}


### PR DESCRIPTION
## what
* Add `eks_cluster_managed_security_group_id` output

## why
* EKS managed Node Groups do not expose nor accept any Security Groups
* Instead, EKS creates a Security Group and applies it to ENI that is attached to EKS Control Plane master nodes and to any managed workloads
* Since that Security Group is applied to the EKS worker nodes, it can be used as a source Security Group for other resources, e.g. `EFS` or `RDS` to allow ingress traffic to the resources

