### PR TITLE
Bumping AWS provider to support version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | kubernetes | ~> 1.11 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
@@ -300,7 +300,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | kubernetes | ~> 1.11 |
 | null | ~> 2.0 |
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 3.0 |
+| aws | >= 2.0, < 4.0 |
 | kubernetes | ~> 1.11 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
@@ -300,7 +300,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 2.0, < 4.0 |
 | kubernetes | ~> 1.11 |
 | null | ~> 2.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 3.0 |
+| aws | >= 2.0, < 4.0 |
 | kubernetes | ~> 1.11 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 2.0, < 4.0 |
 | kubernetes | ~> 1.11 |
 | null | ~> 2.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | kubernetes | ~> 1.11 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 3.0 |
 | kubernetes | ~> 1.11 |
 | null | ~> 2.0 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws        = "~> 2.0"
+    aws        = "~> 3.0"
     template   = "~> 2.0"
     null       = "~> 2.0"
     local      = "~> 1.3"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws        = "~> 3.0"
+    aws        = ">= 2.0, < 4.0"
     template   = "~> 2.0"
     null       = "~> 2.0"
     local      = "~> 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws        = "~> 3.0"
+    aws        = ">= 2.0, < 4.0"
     template   = "~> 2.0"
     null       = "~> 2.0"
     local      = "~> 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws        = "~> 2.0"
+    aws        = "~> 3.0"
     template   = "~> 2.0"
     null       = "~> 2.0"
     local      = "~> 1.3"


### PR DESCRIPTION
## what
* Bumping our AWS provider to support version 2 and 3

## why
* Allows us to take advantage of some newer Terraform features when deploying EKS
* We need this to be in line with `terraform-aws-eks-node-group`, which will provide us with the ability to specify custom launch templates in `aws_eks_node_group`

## references

#### https://github.com/aws/containers-roadmap/issues/585
