### PR TITLE
Feature/output auth token with feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Available targets:
 | allowed\_security\_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
 | apply\_config\_map\_aws\_auth | Whether to apply the ConfigMap to allow worker nodes to join the EKS cluster and allow additional users, accounts and roles to acces the cluster | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| auth\_token\_output\_enable | Set to `true` to output the Kubernetes authentication token | `bool` | `false` | no |
 | cluster\_encryption\_config\_enabled | Set to `true` to enable Cluster Encryption Configuration | `bool` | `false` | no |
 | cluster\_encryption\_config\_kms\_key\_deletion\_window\_in\_days | Cluster Encryption Config KMS Key Resource argument - key deletion windows in days post destruction | `number` | `10` | no |
 | cluster\_encryption\_config\_kms\_key\_enable\_key\_rotation | Cluster Encryption Config KMS Key Resource argument - enable kms key rotation | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Available targets:
 | allowed\_security\_groups | List of Security Group IDs to be allowed to connect to the EKS cluster | `list(string)` | `[]` | no |
 | apply\_config\_map\_aws\_auth | Whether to apply the ConfigMap to allow worker nodes to join the EKS cluster and allow additional users, accounts and roles to acces the cluster | `bool` | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| auth\_token\_output\_enable | Set to `true` to output the Kubernetes authentication token | `bool` | `false` | no |
+| auth\_token\_output\_enabled | Set to `true` to output the Kubernetes authentication token | `bool` | `false` | no |
 | cluster\_encryption\_config\_enabled | Set to `true` to enable Cluster Encryption Configuration | `bool` | `false` | no |
 | cluster\_encryption\_config\_kms\_key\_deletion\_window\_in\_days | Cluster Encryption Config KMS Key Resource argument - key deletion windows in days post destruction | `number` | `10` | no |
 | cluster\_encryption\_config\_kms\_key\_enable\_key\_rotation | Cluster Encryption Config KMS Key Resource argument - enable kms key rotation | `bool` | `true` | no |
@@ -359,6 +359,7 @@ Available targets:
 | cluster\_encryption\_config\_provider\_key\_alias | Cluster Encryption Config KMS Key Alias ARN |
 | cluster\_encryption\_config\_provider\_key\_arn | Cluster Encryption Config KMS Key ARN |
 | cluster\_encryption\_config\_resources | Cluster Encryption Config Resources |
+| cluster\_auth\_token | Cluster Authentication Token. Only available if the `auth_token_output_enabled` feature flag is `true` |
 | eks\_cluster\_arn | The Amazon Resource Name (ARN) of the cluster |
 | eks\_cluster\_certificate\_authority\_data | The Kubernetes cluster certificate authority data |
 | eks\_cluster\_endpoint | The endpoint for the Kubernetes API server |

--- a/outputs.tf
+++ b/outputs.tf
@@ -82,3 +82,8 @@ output "cluster_encryption_config_provider_key_alias" {
   description = "Cluster Encryption Config KMS Key Alias ARN"
   value       = join("", aws_kms_alias.cluster.*.arn)
 }
+
+output "cluster_auth_token" {
+  description = "Cluster Authentication Token"
+  value       = var.auth_token_output_enabled == true ? join("", data.aws_eks_cluster_auth.eks.*.token) : ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,3 +168,9 @@ variable "cluster_encryption_config_resources" {
   default     = ["secrets"]
   description = "Cluster Encryption Config Resources to encrypt, e.g. ['secrets']"
 }
+
+variable "auth_token_output_enabled" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to output the Kubernetes authentication token"
+}


### PR DESCRIPTION
## what
* Added feature flag `auth_token_output_enabled`
* Added `cluster_auth_token` to output the Kubernetes authentication token
* Updated documentation to reflect the aforementioned changes

## why
* Allows operators to use the `helm` provider to install functionality using helm when bootstrapping clusters using the `aws-eks-cluster` module

## references

