### PR TITLE
feat: add k8s provider config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Available targets:
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | kubernetes\_config\_map\_ignore\_role\_changes | Set to `true` to ignore IAM role changes in the Kubernetes Auth ConfigMap | `bool` | `true` | no |
+| kubernetes\_config\_path | Path to the kube config file. Defaults to `~/.kube/config` | `string` | `"~/.kube/config"` | no |
 | kubernetes\_load\_config\_file | Loads the default local config of ~/.kube/config for the provider, which is useful for resolving migration issues like `Error: configmaps "aws-auth" already exists` | `bool` | `false` | no |
 | kubernetes\_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | `string` | `"1.15"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |

--- a/auth.tf
+++ b/auth.tf
@@ -78,7 +78,7 @@ provider "kubernetes" {
   token                  = join("", data.aws_eks_cluster_auth.eks.*.token)
   host                   = join("", data.aws_eks_cluster.eks.*.endpoint)
   cluster_ca_certificate = base64decode(join("", data.aws_eks_cluster.eks.*.certificate_authority.0.data))
-  load_config_file       = false
+  load_config_file       = var.kubernetes_load_config_file
 }
 
 resource "kubernetes_config_map" "aws_auth_ignore_changes" {

--- a/auth.tf
+++ b/auth.tf
@@ -79,6 +79,7 @@ provider "kubernetes" {
   host                   = join("", data.aws_eks_cluster.eks.*.endpoint)
   cluster_ca_certificate = base64decode(join("", data.aws_eks_cluster.eks.*.certificate_authority.0.data))
   load_config_file       = var.kubernetes_load_config_file
+  config_path            = var.kubernetes_config_path
 }
 
 resource "kubernetes_config_map" "aws_auth_ignore_changes" {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -43,6 +43,7 @@
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | kubernetes\_config\_map\_ignore\_role\_changes | Set to `true` to ignore IAM role changes in the Kubernetes Auth ConfigMap | `bool` | `true` | no |
+| kubernetes\_config\_path | Path to the kube config file. Defaults to `~/.kube/config` | `string` | `"~/.kube/config"` | no |
 | kubernetes\_load\_config\_file | Loads the default local config of ~/.kube/config for the provider, which is useful for resolving migration issues like `Error: configmaps "aws-auth" already exists` | `bool` | `false` | no |
 | kubernetes\_version | Desired Kubernetes master version. If you do not specify a value, the latest available version is used | `string` | `"1.15"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -43,9 +43,15 @@ variable "kubernetes_version" {
   description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used"
 }
 
+variable "kubernetes_config_path" {
+  type        = string
+  default     = "~/.kube/config"
+  description = "Path to the kube config file. Defaults to `~/.kube/config`"
+}
+
 variable "kubernetes_load_config_file" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Loads the default local config of ~/.kube/config for the provider, which is useful for resolving migration issues like `Error: configmaps \"aws-auth\" already exists`"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "kubernetes_version" {
   description = "Desired Kubernetes master version. If you do not specify a value, the latest available version is used"
 }
 
+variable "kubernetes_load_config_file" {
+  type = bool
+  default = false
+  description = "Loads the default local config of ~/.kube/config for the provider, which is useful for resolving migration issues like `Error: configmaps \"aws-auth\" already exists`"
+}
+
 variable "oidc_provider_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Adds variable for `kubernetes.load_config_file` configuration via `kubernetes_load_config_file`
* Add variable for `kubernetes.config_path` configuration via `kubernetes_config_path`

## why
* Allow bypassing issues with clusters provisioned with different users by migrating from `null` config map resource to native `kubernetes` provider config map resource

## references
* Closes #77 

