### PR TITLE
Terraform 0.14 upgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Use this file to define individuals or teams that are responsible for code in a repository.
 # Read more: <https://help.github.com/articles/about-codeowners/>
 #
-# Order is important: the last matching pattern takes the most precedence
+# Order is important: the last matching pattern has the highest precedence
 
 # These owners will be the default owners for everything
 *             @cloudposse/engineering @cloudposse/contributors
@@ -16,8 +16,8 @@
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
 **/context.tf   @cloudposse/engineering @cloudposse/approvers
-README.md       @cloudposse/engineering @cloudposse/approvers
-docs/*.md       @cloudposse/engineering @cloudposse/approvers
+README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 
 # Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
 .github/mergify.yml @cloudposse/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,12 @@
 # Cloud Posse must review any changes to GitHub actions
 .github/*     @cloudposse/engineering
 
-# Cloud Posse must review any changes to standard context definition
-**/context.tf   @cloudposse/engineering
+# Cloud Posse must review any changes to standard context definition,
+# but some changes can be rubber-stamped.
+**/context.tf   @cloudposse/engineering @cloudposse/approvers
+README.md       @cloudposse/engineering @cloudposse/approvers
+docs/*.md       @cloudposse/engineering @cloudposse/approvers
+
+# Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
+.github/mergify.yml @cloudposse/admins
+.github/CODEOWNERS  @cloudposse/admins

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -4,30 +4,35 @@ version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:
   major:
     labels:
-      - 'major'
+    - 'major'
   minor:
     labels:
-      - 'minor'
-      - 'enhancement'
+    - 'minor'
+    - 'enhancement'
   patch:
     labels:
-      - 'patch'
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-      - 'hotfix'
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
   default: 'minor'
 
 categories:
-  - title: '🚀 Enhancements'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-      - 'hotfix'
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
 
 change-template: |
   <details>

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,52 @@
+pull_request_rules:
+- name: "approve automated PRs that have passed checks"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "author=cloudpossebot"
+  - "head~=auto-update/.*"
+  actions:
+    review:
+      type: "APPROVE"
+      bot_account: "cloudposse-mergebot"
+      message: "We've automatically approved this PR because the checks from the automated Pull Request have passed."
+
+- name: "merge automated PRs when approved and tests pass"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "head~=auto-update/.*"
+  - "#approved-reviews-by>=1"
+  - "#changes-requested-reviews-by=0"
+  - "#commented-reviews-by=0"
+  - "base=master"
+  - "author=cloudpossebot"
+  actions:
+    merge:
+      method: "squash"
+
+- name: "delete the head branch after merge"
+  conditions:
+  - "merged"
+  actions:
+    delete_head_branch: {}
+
+- name: "ask to resolve conflict"
+  conditions:
+  - "conflict"
+  actions:
+    comment:
+      message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"
+
+- name: "remove outdated reviews"
+  conditions:
+  - "base=master"
+  actions:
+    dismiss_reviews:
+      changes_requested: true
+      approved: true
+      message: "This Pull Request has been updated, so we're dismissing all reviews."

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -34,7 +34,7 @@ jobs:
         fi
 
     - name: Create Pull Request
-      if: {{ steps.update.outputs.create_pull_request == 'true' }}
+      if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -1,0 +1,54 @@
+name: "auto-context"
+on:
+  schedule:
+  # Update context.tf nightly
+  - cron:  '0 3 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update context.tf
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        if [[ -f context.tf ]]; then
+          echo "Discovered existing context.tf! Fetching most recent version to see if there is an update."
+          curl -o context.tf -fsSL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf
+          if git diff --no-patch --exit-code context.tf; then
+            echo "No changes detected! Exiting the job..."
+          else
+            echo "context.tf file was updated. Need to rebuild README.md."
+            make init
+            make readme/build
+            echo "::set-output name=create_pull_request=true"
+          fi
+        else
+          echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
+        fi
+
+    - name: Create Pull Request
+      if: {{ steps.update.outputs.create_pull_request == 'true' }}
+      uses: cloudposse/actions/github/create-pull-request@0.20.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update context.tf from origin source
+        title: Update context.tf
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the `context.tf` file to the latest version from `cloudposse/terraform-null-label`
+
+          ## why
+          To support all the features of the `context` interface.
+
+        branch: auto-update/context.tf
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          context

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -23,8 +23,9 @@ jobs:
           if git diff --no-patch --exit-code context.tf; then
             echo "No changes detected! Exiting the job..."
           else
-            echo "context.tf file was updated. Need to rebuild README.md."
+            echo "context.tf file has changed. Update examples and rebuild README.md."
             make init
+            make github/init/context.tf
             make readme/build
             echo "::set-output name=create_pull_request=true"
           fi
@@ -34,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: {{ steps.update.outputs.create_pull_request == 'true' }}
-      uses: cloudposse/actions/github/create-pull-request@0.20.0
+      uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,41 @@
+name: "auto-readme"
+on:
+  schedule:
+  # Update README.md nightly
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        make init
+        make readme/build
+
+    - name: Create Pull Request
+      uses: cloudposse/actions/github/create-pull-request@0.20.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          readme

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,17 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-          prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,6 +9,8 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
@@ -16,3 +18,8 @@ jobs:
         checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+    - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      name: "Syntax check of CODEOWNERS"
+      with:
+        checks: "syntax,duppatterns"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,9 +1,6 @@
 name: Validate Codeowners
 on:
   pull_request:
-    paths:
-    - '**/CODEOWNERS'
-    - '.github/workflows/validate-codeowners.yml'
 
 jobs:
   validate-codeowners:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,18 @@
+name: Validate Codeowners
+on:
+  pull_request:
+    paths:
+    - '**/CODEOWNERS'
+    - '.github/workflows/validate-codeowners.yml'
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v2
+    - uses: mszostok/codeowners-validator@v0.5.0
+      with:
+        checks: "files,syntax,owners,duppatterns"
+        # GitHub access token is required only if the `owners` check is enabled
+        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -13,6 +13,9 @@ jobs:
       uses: actions/checkout@v2
     - uses: mszostok/codeowners-validator@v0.5.0
       with:
-        checks: "files,syntax,owners,duppatterns"
+        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
+        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
+        #   checks: "files,syntax,owners,duppatterns"
+        checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry (hashicorp/terraform#21417),
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
 the registry shows many of our inputs as required when in fact they are optional.
 The table below correctly indicates which inputs are required.
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,15 @@ set the variable `kubernetes_config_map_ignore_role_changes` to `false` and re-p
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-eks-cluster/releases).
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
+
+Also, because of a bug in the Terraform registry (hashicorp/terraform#21417),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
 
 
@@ -107,7 +114,9 @@ Other examples:
   }
 
   module "label" {
-    source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
+    source = "cloudposse/label/null"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace  = var.namespace
     name       = var.name
     stage      = var.stage
@@ -131,7 +140,9 @@ Other examples:
   }
 
   module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
+    source = "cloudposse/vpc/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace  = var.namespace
     stage      = var.stage
     name       = var.name
@@ -141,7 +152,9 @@ Other examples:
   }
 
   module "subnets" {
-    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
+    source = "cloudposse/dynamic-subnets/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     availability_zones   = var.availability_zones
     namespace            = var.namespace
     stage                = var.stage
@@ -156,7 +169,9 @@ Other examples:
   }
 
   module "eks_workers" {
-    source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+    source = "cloudposse/eks-workers/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace                          = var.namespace
     stage                              = var.stage
     name                               = var.name
@@ -182,7 +197,9 @@ Other examples:
   }
 
   module "eks_cluster" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+    source = "cloudposse/eks-cluster/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace  = var.namespace
     stage      = var.stage
     name       = var.name
@@ -203,7 +220,9 @@ Module usage with two worker groups:
 
 ```hcl
   module "eks_workers" {
-    source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+    source = "cloudposse/eks-workers/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace                          = var.namespace
     stage                              = var.stage
     name                               = "small"
@@ -228,7 +247,9 @@ Module usage with two worker groups:
   }
 
   module "eks_workers_2" {
-    source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+    source = "cloudposse/eks-workers/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace                          = var.namespace
     stage                              = var.stage
     name                               = "medium"
@@ -253,7 +274,9 @@ Module usage with two worker groups:
   }
 
   module "eks_cluster" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+    source = "cloudposse/eks-cluster/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace  = var.namespace
     stage      = var.stage
     name       = var.name
@@ -292,7 +315,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | kubernetes | >= 1.11 |
 | local | >= 1.3 |

--- a/README.yaml
+++ b/README.yaml
@@ -87,7 +87,9 @@ usage: |2-
     }
 
     module "label" {
-      source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=master"
+      source = "cloudposse/label/null"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace  = var.namespace
       name       = var.name
       stage      = var.stage
@@ -111,7 +113,9 @@ usage: |2-
     }
 
     module "vpc" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
+      source = "cloudposse/vpc/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace  = var.namespace
       stage      = var.stage
       name       = var.name
@@ -121,7 +125,9 @@ usage: |2-
     }
 
     module "subnets" {
-      source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=master"
+      source = "cloudposse/dynamic-subnets/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       availability_zones   = var.availability_zones
       namespace            = var.namespace
       stage                = var.stage
@@ -136,7 +142,9 @@ usage: |2-
     }
 
     module "eks_workers" {
-      source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+      source = "cloudposse/eks-workers/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace                          = var.namespace
       stage                              = var.stage
       name                               = var.name
@@ -162,7 +170,9 @@ usage: |2-
     }
 
     module "eks_cluster" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+      source = "cloudposse/eks-cluster/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace  = var.namespace
       stage      = var.stage
       name       = var.name
@@ -183,7 +193,9 @@ usage: |2-
 
   ```hcl
     module "eks_workers" {
-      source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+      source = "cloudposse/eks-workers/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace                          = var.namespace
       stage                              = var.stage
       name                               = "small"
@@ -208,7 +220,9 @@ usage: |2-
     }
 
     module "eks_workers_2" {
-      source                             = "git::https://github.com/cloudposse/terraform-aws-eks-workers.git?ref=master"
+      source = "cloudposse/eks-workers/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace                          = var.namespace
       stage                              = var.stage
       name                               = "medium"
@@ -233,7 +247,9 @@ usage: |2-
     }
 
     module "eks_cluster" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-eks-cluster.git?ref=master"
+      source = "cloudposse/eks-cluster/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
       namespace  = var.namespace
       stage      = var.stage
       name       = var.name

--- a/context.tf
+++ b/context.tf
@@ -18,8 +18,10 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
+
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
+  source  = "cloudposse/label/null"
+  version = "0.22.0" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | kubernetes | >= 1.11 |
 | local | >= 1.3 |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -18,8 +18,10 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
+
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.22.0" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source     = "cloudposse/label/null"
+  version    = "0.19.2"
   attributes = ["cluster"]
 
   context = module.this.context
@@ -33,7 +34,8 @@ locals {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.17.0"
+  source  = "cloudposse/vpc/aws"
+  version = "0.17.0"
 
   cidr_block = "172.16.0.0/16"
   tags       = local.tags
@@ -42,7 +44,8 @@ module "vpc" {
 }
 
 module "subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.28.0"
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "0.28.0"
 
   availability_zones              = var.availability_zones
   vpc_id                          = module.vpc.vpc_id
@@ -86,7 +89,8 @@ data "null_data_source" "wait_for_cluster_and_kubernetes_configmap" {
 }
 
 module "eks_node_group" {
-  source = "git::https://github.com/cloudposse/terraform-aws-eks-node-group.git?ref=tags/0.8.0"
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.8.0"
 
   subnet_ids        = module.subnets.private_subnet_ids
   cluster_name      = data.null_data_source.wait_for_cluster_and_kubernetes_configmap.outputs["cluster_name"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "label" {
   source     = "cloudposse/label/null"
-  version    = "0.19.2"
+  version    = "0.22.0"
   attributes = ["cluster"]
 
   context = module.this.context

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,11 +1,26 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws        = ">= 2.0, < 4.0"
-    template   = "~> 2.0"
-    null       = "~> 2.0"
-    local      = "~> 1.3"
-    kubernetes = "~> 1.11"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 1.11"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 module "label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.19.2"
 
   # Using attributes = ["cluster"] would put "cluster" before any user-specified attributes.
   # While that might be preferable (adding an attribute "blue" would create

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,26 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws        = ">= 2.0"
-    template   = ">= 2.0"
-    null       = ">= 2.0"
-    local      = ">= 1.3"
-    kubernetes = ">= 1.11"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 1.11"
+    }
   }
 }


### PR DESCRIPTION
## what
- Standard Terraform 0.14 upgrade

## why
- Support Terraform 0.14
- Update to current Cloud Posse standards for Terraform modules

## notes
- Supersedes and closes #87 

