### PR TITLE
Updates for TF 0.14, pin Kubernetes provider

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -43,3 +43,11 @@ change-template: |
 
 template: |
   $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,16 @@
+# https://docs.mergify.io/conditions.html
+# https://docs.mergify.io/actions.html
 pull_request_rules:
 - name: "approve automated PRs that have passed checks"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "author=cloudpossebot"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   actions:
     review:
       type: "APPROVE"
@@ -15,16 +19,17 @@ pull_request_rules:
 
 - name: "merge automated PRs when approved and tests pass"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   - "#approved-reviews-by>=1"
   - "#changes-requested-reviews-by=0"
   - "#commented-reviews-by=0"
-  - "base=master"
-  - "author=cloudpossebot"
   actions:
     merge:
       method: "squash"
@@ -38,6 +43,7 @@ pull_request_rules:
 - name: "ask to resolve conflict"
   conditions:
   - "conflict"
+  - "-closed"
   actions:
     comment:
       message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -38,6 +38,8 @@ jobs:
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,86 @@
+name: Auto Format
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    container: cloudposse/build-harness:slim-latest
+    steps:
+    # Checkout the pull request branch
+    #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
+    #   the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains
+    #   a workflow configured to run when push events occur."
+    # However, using a personal access token will cause events to be triggered.
+    # We need that to ensure a status gets posted after the auto-format commit.
+    # We also want to trigger tests if the auto-format made no changes.
+    - uses: actions/checkout@v2
+      if: github.event.pull_request.state == 'open'
+      name: Privileged Checkout
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Check out the PR commit, not the merge commit
+        # Use `ref` instead of `sha` to enable pushing back to `ref`
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Do all the formatting stuff
+    - name: Auto Format
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
+
+    # Commit changes (if any) to the PR branch
+    - name: Commit changes to the PR branch
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      id: commit
+      env:
+        SENDER: ${{ github.event.sender.login }}
+      run: |
+        set -x
+        output=$(git diff --name-only)
+
+        if [ -n "$output" ]; then
+          echo "Changes detected. Pushing to the PR branch"
+          git config --global user.name 'cloudpossebot'
+          git config --global user.email '11232728+cloudpossebot@users.noreply.github.com'
+          git add -A
+          git commit -m "Auto Format"
+          # Prevent looping by not pushing changes in response to changes from cloudpossebot
+          [[ $SENDER ==  "cloudpossebot" ]] || git push
+          # Set status to fail, because the push should trigger another status check,
+          # and we use success to indicate the checks are finished.
+          printf "::set-output name=%s::%s\n" "changed" "true"
+          exit 1
+        else
+          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "No changes detected"
+        fi
+
+    - name: Auto Test
+      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      # match users by ID because logins (user names) are inconsistent,
+      # for example in the REST API Renovate Bot is `renovate[bot]` but
+      # in GraphQL it is just `renovate`, plus there is a non-bot
+      # user `renovate` with ID 1832810.
+      # Mergify bot: 37929162
+      # Renovate bot: 29139614
+      # Cloudpossebot: 11232728
+      # Need to use space separators to prevent "21" from matching "112144"
+      if: >
+        contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
+        && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: cloudposse/actions
+        event-type: test-command
+        client-payload: |-
+          { "slash_command":{"args": {"unnamed": {"all": "all", "arg1": "all"}}},
+             "pull_request": ${{ toJSON(github.event.pull_request) }},
+             "github":{"payload":{"repository": ${{ toJSON(github.event.repository) }},
+                                  "comment": {"id": ""}
+                                 }
+                      }
+          }

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  semver:
+  publish:
     runs-on: ubuntu-latest
     steps:
     # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| kubernetes | >= 1.11 |
+| kubernetes | ~> 1.11 |
 | local | >= 1.3 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -327,7 +327,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| kubernetes | >= 1.11 |
+| kubernetes | ~> 1.11 |
 | null | >= 2.0 |
 
 ## Inputs
@@ -498,7 +498,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/context.tf
+++ b/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| kubernetes | >= 1.11 |
+| kubernetes | ~> 1.11 |
 | local | >= 1.3 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -15,7 +15,7 @@
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| kubernetes | >= 1.11 |
+| kubernetes | ~> 1.11 |
 | null | >= 2.0 |
 
 ## Inputs

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -9,13 +9,9 @@ locals {
 
 module "label" {
   source  = "cloudposse/label/null"
-  version = "0.22.0"
+  version = "0.22.1"
 
-  # Using attributes = ["cluster"] would put "cluster" before any user-specified attributes.
-  # While that might be preferable (adding an attribute "blue" would create
-  # ...name-cluster-blue instead of ...name-blue-cluster), historically we forced "cluster"
-  # to the end of the attribute list, so we do it again here to maintain compatibility.
-  attributes = compact(concat(module.this.attributes, ["cluster"]))
+  attributes = ["cluster"]
 
   context = module.this.context
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,9 @@ clean:
 all: module examples/complete
 
 ## Run basic sanity checks against the module itself
-module: export TESTS ?= installed lint get-modules module-pinning get-plugins provider-pinning validate terraform-docs input-descriptions output-descriptions
+# module: export TESTS ?= installed lint get-modules module-pinning get-plugins provider-pinning validate terraform-docs input-descriptions output-descriptions
+# The kubernetes provider needs to be pinned because 2.x has breaking changes
+module: export TESTS ?= installed lint get-modules module-pinning get-plugins validate terraform-docs input-descriptions output-descriptions
 module: deps
 	$(call RUN_TESTS, ../)
 

--- a/versions.tf
+++ b/versions.tf
@@ -19,8 +19,10 @@ terraform {
       version = ">= 1.3"
     }
     kubernetes = {
+      # Version 2.0 has breaking changes, this module needs conversion to use it.
+      # After converting to 2.0, restore the provider-pinning Bats test in test/Makefile
       source  = "hashicorp/kubernetes"
-      version = ">= 1.11"
+      version = "~> 1.11"
     }
   }
 }


### PR DESCRIPTION
## what
- Pin Kubernetes provider to avoid v2.0 breaking changes
- Updates for TF 0.14 
- Update `context.tf` to 0.22.1`

## why
- Kubernetes v2.0 has breaking changes, create a pinned version to allow continued use by existing modules without forcing them to update providers
- Stay current

## notes
- Closes #89 
- Closes #90 
- Closes #91 
