### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_eks_cluster" "default" {
 
   vpc_config {
     security_group_ids      = [join("", aws_security_group.default.*.id)]
-    subnet_ids              = var.subnet_ids
+    subnet_ids              = sort(var.subnet_ids)
     endpoint_private_access = var.endpoint_private_access
     endpoint_public_access  = var.endpoint_public_access
     public_access_cidrs     = var.public_access_cidrs


### PR DESCRIPTION
I have changed the passing of kubernetes subnets as sorted array. I faced an issue in some case when terraform is not getting the exact array from AWS while describing the subnets as passed by vars through terraform and subsequently terraform plan is suggesting to delete the cluster and create a new on . So if this is changed to sorted then it will compare them as sorted array and both will be equal. This is an edge case. It happened with me in 1 out of 2 VPCs I created. 

References:
https://github.com/hashicorp/terraform-provider-aws/issues/15113