### PR TITLE
Set `hashicorp/kubernetes` lower bound to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Available targets:
 |------|---------|
 | terraform | >= 0.13.0 |
 | aws | >= 2.0 |
-| kubernetes | >= 2.0 |
+| kubernetes | >= 1.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -346,7 +346,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| kubernetes | >= 2.0 |
+| kubernetes | >= 1.0 |
 | null | >= 2.0 |
 
 ## Modules

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 |------|---------|
 | terraform | >= 0.13.0 |
 | aws | >= 2.0 |
-| kubernetes | >= 2.0 |
+| kubernetes | >= 1.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |
 | template | >= 2.0 |
@@ -15,7 +15,7 @@
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| kubernetes | >= 2.0 |
+| kubernetes | >= 1.0 |
 | null | >= 2.0 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 1.0"
     }
   }
 }


### PR DESCRIPTION
## what

* `hashicorp/kubernetes` provider 2.0 breaks terraform-aws-eks-cluster

## why

* The lower bound allows consumers to use `~> 1.0` to force the 1.0 version of the provider

## references

* https://github.com/cloudposse/terraform-aws-eks-cluster/issues/96
* https://github.com/cloudposse/terraform-aws-eks-cluster/issues/104
* hashicorp/terraform-provider-kubernetes#1095
* hashicorp/terraform#4149
