### PR TITLE
OIDC thumbprint_list can be retrieved and tags added to OIDC provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-eks-cluster [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-eks-cluster.svg)](https://github.com/cloudposse/terraform-aws-eks-cluster/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to provision an [EKS](https://aws.amazon.com/eks/) cluster on AWS.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -59,7 +59,6 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
-
 ## Introduction
 
 The module provisions the following resources:
@@ -83,6 +82,7 @@ __NOTE:__ In `auth.tf`, we added `ignore_changes = [data["mapRoles"]]` to the `k
 
 If you want to modify the Node Group (e.g. add more Node Groups to the cluster) or need to map other IAM roles to Kubernetes groups,
 set the variable `kubernetes_config_map_ignore_role_changes` to `false` and re-provision the module. Then set `kubernetes_config_map_ignore_role_changes` back to `true`.
+
 
 ## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
 
@@ -340,6 +340,7 @@ Available targets:
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.2.0 |
 
 ## Providers
 
@@ -348,6 +349,7 @@ Available targets:
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.2.0 |
 
 ## Modules
 
@@ -382,6 +384,7 @@ Available targets:
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_elb_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [tls_certificate.cluster](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 
@@ -463,6 +466,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -477,8 +481,6 @@ Check out these related projects.
 - [terraform-aws-ecs-cloudwatch-sns-alarms](https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms) - Terraform module to create CloudWatch Alarms on ECS Service level metrics
 - [terraform-aws-ec2-instance](https://github.com/cloudposse/terraform-aws-ec2-instance) - Terraform module for providing a general purpose EC2 instance
 - [terraform-aws-ec2-instance-group](https://github.com/cloudposse/terraform-aws-ec2-instance-group) - Terraform module for provisioning multiple general purpose EC2 hosts for stateful applications
-
-
 
 ## Help
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,6 +9,7 @@
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.2.0 |
 
 ## Providers
 
@@ -17,6 +18,7 @@
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.2.0 |
 
 ## Modules
 
@@ -51,6 +53,7 @@
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_elb_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [tls_certificate.cluster](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ resource "aws_eks_cluster" "default" {
 #
 
 data "tls_certificate" "cluster" {
+  count = (local.enabled && var.oidc_provider_enabled) ? 1 : 0
   url = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "aws_eks_cluster" "default" {
 
 data "tls_certificate" "cluster" {
   count = (local.enabled && var.oidc_provider_enabled) ? 1 : 0
-  url = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+  url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
 }
 
 resource "aws_iam_openid_connect_provider" "default" {

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_eks_cluster" "default" {
 #
 
 data "tls_certificate" "cluster" {
-  url =  join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+  url = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
 }
 
 resource "aws_iam_openid_connect_provider" "default" {
@@ -94,7 +94,7 @@ resource "aws_iam_openid_connect_provider" "default" {
   url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
   tags  = module.label.tags
 
-  client_id_list = ["sts.amazonaws.com"]
+  client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.tls_certificate.cluster.certificates.0.sha1_fingerprint]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -84,13 +84,17 @@ resource "aws_eks_cluster" "default" {
 # https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
 # https://medium.com/@marcincuber/amazon-eks-with-oidc-provider-iam-roles-for-kubernetes-services-accounts-59015d15cb0c
 #
+
+data "tls_certificate" "cluster" {
+  url =  join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+}
+
 resource "aws_iam_openid_connect_provider" "default" {
   count = (local.enabled && var.oidc_provider_enabled) ? 1 : 0
   url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+  tags  = module.label.tags
 
   client_id_list = ["sts.amazonaws.com"]
-
-  # it's thumbprint won't change for many years
-  # https://github.com/terraform-providers/terraform-provider-aws/issues/10104
-  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+  thumbprint_list = [data.tls_certificate.cluster.certificates.0.sha1_fingerprint]
 }
+

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,5 @@ resource "aws_iam_openid_connect_provider" "default" {
   tags  = module.label.tags
 
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.cluster.certificates.0.sha1_fingerprint]
+  thumbprint_list = [join("", data.tls_certificate.cluster.*.certificates.0.sha1_fingerprint)]
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 1.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 2.2.0"
+    }
   }
 }


### PR DESCRIPTION
## what/why
* Thanks to https://github.com/hashicorp/terraform-provider-tls/pull/62 the `sha1_fingerprint` can be set automatically instead of be hardcoded, which is prone to error since some region has a different one.
* Minor, but useful: the OIDC provider wasn't tagged, which makes hard to find it and delete if the cluster is gone. I've just added the beloved `module.label.tags`

## references
* https://github.com/hashicorp/terraform-provider-tls/issues/52 and related PR: https://github.com/hashicorp/terraform-provider-tls/pull/62
* The change is also reported into the data source examples: https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/tls_certificate
