### PR TITLE
Fix order of roles in auth-map, update example

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -139,7 +139,7 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 
   data = {
-    mapRoles    = replace(yamlencode(distinct(concat(var.map_additional_iam_roles, local.map_worker_roles))), "\"", local.yaml_quote)
+    mapRoles    = replace(yamlencode(distinct(concat(local.map_worker_roles, var.map_additional_iam_roles))), "\"", local.yaml_quote)
     mapUsers    = replace(yamlencode(var.map_additional_iam_users), "\"", local.yaml_quote)
     mapAccounts = replace(yamlencode(var.map_additional_aws_accounts), "\"", local.yaml_quote)
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -44,7 +44,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "0.38.0"
+  version = "0.39.3"
 
   availability_zones              = var.availability_zones
   vpc_id                          = module.vpc.vpc_id


### PR DESCRIPTION
## what

Quick fixes to #119
- Incorporate #120 
- Insert roles into `aws-auth` in the correct order when not ignoring them

## why
- Reduce complaints from Terraform
