### PR TITLE
Disallow TLS provider v4 due to provider issue 244

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Available targets:
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0, < 4.0.0 |
 
 ## Providers
 
@@ -406,7 +406,7 @@ Available targets:
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0, < 4.0.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,7 +7,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1.0, < 4.0.0 |
 
 ## Providers
 
@@ -16,7 +16,7 @@
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1.0, < 4.0.0 |
 
 ## Modules
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,9 @@ clean:
 all: module examples/complete
 
 ## Run basic sanity checks against the module itself
-module: export TESTS ?= installed lint module-pinning provider-pinning validate terraform-docs input-descriptions output-descriptions
+# disable provider-pinning test due to https://github.com/hashicorp/terraform-provider-tls/issues/244
+#module: export TESTS ?= installed lint module-pinning provider-pinning validate terraform-docs input-descriptions output-descriptions
+module: export TESTS ?= installed lint module-pinning validate terraform-docs input-descriptions output-descriptions
 module: deps
 	$(call RUN_TESTS, ../)
 

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.1.0"
+      version = ">= 3.1.0, < 4.0.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what

- Disallow `hashicorp/tls` provider version >= 4.0.0

## why

When using `hashicorp/tls` provider v4.0.0 and setting `oidc_provider_enabled = true` on a new EKS cluster deployment, `terraform plan` will fail with `thumbprint_list = [join("", data.tls_certificate.cluster.*.certficates.0.sha1_fingerprint)]` and `The given key does not identify an element in this collection value: the collection has no elements.`


## references

- https://github.com/hashicorp/terraform-provider-tls/issues/244
