### PR TITLE
Avoid triggering new "conflicts with" rule in 2.21.0 Kubernetes provider

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -102,7 +102,7 @@ provider "kubernetes" {
   token                  = local.kube_data_auth_enabled ? one(data.aws_eks_cluster_auth.eks[*].token) : null
   # The Kubernetes provider will use information from KUBECONFIG if it exists, but if the default cluster
   # in KUBECONFIG is some other cluster, this will cause problems, so we override it always.
-  config_path    = local.kubeconfig_path_enabled ? var.kubeconfig_path : ""
+  config_path    = local.kubeconfig_path_enabled ? var.kubeconfig_path : null
   config_context = var.kubeconfig_context
 
   dynamic "exec" {


### PR DESCRIPTION
Closes #188 

## what

Avoids triggering the "conflicts with" error that now crops up with the latest version (2.21.0) of the Kubernetes provider.

## why

Terraform actions involving this module and the latest Kubernetes provider fail.

## references

https://github.com/hashicorp/terraform-provider-kubernetes/releases/tag/v2.21.0
https://github.com/hashicorp/terraform-provider-kubernetes/pull/2084