### PR TITLE
Feature/update resolve conflicts

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -247,21 +247,24 @@ usage: |2-
         {
           addon_name               = "vpc-cni"
           addon_version            = var.vpc_cni_version
-          resolve_conflicts        = "NONE"
+          resolve_conflicts_on_create = "NONE"
+          resolve_conflicts_on_update = "NONE"
           service_account_role_arn = null
         },
         // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
         {
           addon_name               = "kube-proxy"
           addon_version            = var.kube_proxy_version
-          resolve_conflicts        = "NONE"
+          resolve_conflicts_on_create = "NONE"
+          resolve_conflicts_on_update = "NONE"
           service_account_role_arn = null
         },
         // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
         {
           addon_name               = "coredns"
           addon_version            = var.coredns_version
-          resolve_conflicts        = "NONE"
+          resolve_conflicts_on_create = "NONE"
+          resolve_conflicts_on_update = "NONE"
           service_account_role_arn = null
         },
       ]

--- a/README.yaml
+++ b/README.yaml
@@ -245,27 +245,27 @@ usage: |2-
       addons = [
         // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
         {
-          addon_name               = "vpc-cni"
-          addon_version            = var.vpc_cni_version
+          addon_name                  = "vpc-cni"
+          addon_version               = var.vpc_cni_version
           resolve_conflicts_on_create = "NONE"
           resolve_conflicts_on_update = "NONE"
-          service_account_role_arn = null
+          service_account_role_arn    = null
         },
         // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
         {
-          addon_name               = "kube-proxy"
-          addon_version            = var.kube_proxy_version
+          addon_name                  = "kube-proxy"
+          addon_version               = var.kube_proxy_version
           resolve_conflicts_on_create = "NONE"
           resolve_conflicts_on_update = "NONE"
-          service_account_role_arn = null
+          service_account_role_arn    = null
         },
         // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
         {
-          addon_name               = "coredns"
-          addon_version            = var.coredns_version
+          addon_name                  = "coredns"
+          addon_version               = var.coredns_version
           resolve_conflicts_on_create = "NONE"
           resolve_conflicts_on_update = "NONE"
-          service_account_role_arn = null
+          service_account_role_arn    = null
         },
       ]
       addons_depends_on = [module.eks_node_group]

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -33,23 +33,26 @@ kubernetes_version = "1.26"
 addons = [
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#vpc-cni-latest-available-version
   {
-    addon_name               = "vpc-cni"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "vpc-cni"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   {
-    addon_name               = "kube-proxy"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "kube-proxy"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
   // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   {
-    addon_name               = "coredns"
-    addon_version            = null
-    resolve_conflicts        = "NONE"
-    service_account_role_arn = null
+    addon_name                  = "coredns"
+    addon_version               = null
+    resolve_conflicts_on_create = "NONE"
+    resolve_conflicts_on_update = "NONE"
+    service_account_role_arn    = null
   },
 ]

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -132,11 +132,11 @@ variable "cluster_encryption_config_resources" {
 
 variable "addons" {
   type = list(object({
-    addon_name               = string
-    addon_version            = string
+    addon_name                  = string
+    addon_version               = string
     resolve_conflicts_on_create = string
     resolve_conflicts_on_update = string
-    service_account_role_arn = string
+    service_account_role_arn    = string
   }))
   default     = []
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources."

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -134,7 +134,8 @@ variable "addons" {
   type = list(object({
     addon_name               = string
     addon_version            = string
-    resolve_conflicts        = string
+    resolve_conflicts_on_create = string
+    resolve_conflicts_on_update = string
     service_account_role_arn = string
   }))
   default     = []

--- a/main.tf
+++ b/main.tf
@@ -142,12 +142,13 @@ resource "aws_eks_addon" "cluster" {
     addon.addon_name => addon
   } : {}
 
-  cluster_name             = one(aws_eks_cluster.default[*].name)
-  addon_name               = each.key
-  addon_version            = lookup(each.value, "addon_version", null)
-  configuration_values     = lookup(each.value, "configuration_values", null)
-  resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
-  service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
+  cluster_name                = one(aws_eks_cluster.default[*].name)
+  addon_name                  = each.key
+  addon_version               = lookup(each.value, "addon_version", null)
+  configuration_values        = lookup(each.value, "configuration_values", null)
+  resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts_on_create", null)
+  resolve_conflicts_on_update = lookup(each.value, "resolve_conflicts_on_update", null)
+  service_account_role_arn    = lookup(each.value, "service_account_role_arn", null)
 
   tags = module.label.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -209,14 +209,15 @@ variable "cloudwatch_log_group_kms_key_id" {
 
 variable "addons" {
   type = list(object({
-    addon_name               = string
-    addon_version            = optional(string, null)
-    configuration_values     = optional(string, null)
-    resolve_conflicts        = string
-    service_account_role_arn = optional(string, null)
-    create_timeout           = optional(string, null)
-    update_timeout           = optional(string, null)
-    delete_timeout           = optional(string, null)
+    addon_name                  = string
+    addon_version               = optional(string, null)
+    configuration_values        = optional(string, null)
+    resolve_conflicts_on_create = optional(string, null)
+    resolve_conflicts_on_update = optional(string, null)
+    service_account_role_arn    = optional(string, null)
+    create_timeout              = optional(string, null)
+    update_timeout              = optional(string, null)
+    delete_timeout              = optional(string, null)
   }))
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources"
   default     = []


### PR DESCRIPTION
## what

Updating the addon to use `resolve_conflicts_on_create` and `resolve_conflicts_on_update`. 

## why

Per reference below, `resolve_conflicts` is deprecated. 

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon
