### PR TITLE
Output addons_versions if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Available targets:
 | <a name="output_cluster_encryption_config_provider_key_alias"></a> [cluster\_encryption\_config\_provider\_key\_alias](#output\_cluster\_encryption\_config\_provider\_key\_alias) | Cluster Encryption Config KMS Key Alias ARN |
 | <a name="output_cluster_encryption_config_provider_key_arn"></a> [cluster\_encryption\_config\_provider\_key\_arn](#output\_cluster\_encryption\_config\_provider\_key\_arn) | Cluster Encryption Config KMS Key ARN |
 | <a name="output_cluster_encryption_config_resources"></a> [cluster\_encryption\_config\_resources](#output\_cluster\_encryption\_config\_resources) | Cluster Encryption Config Resources |
+| <a name="output_eks_addons_versions"></a> [eks\_addons\_versions](#output\_eks\_addons\_versions) | Map of enabled EKS Addons names and versions |
 | <a name="output_eks_cluster_arn"></a> [eks\_cluster\_arn](#output\_eks\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
 | <a name="output_eks_cluster_certificate_authority_data"></a> [eks\_cluster\_certificate\_authority\_data](#output\_eks\_cluster\_certificate\_authority\_data) | The Kubernetes cluster certificate authority data |
 | <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | The endpoint for the Kubernetes API server |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -118,6 +118,7 @@
 | <a name="output_cluster_encryption_config_provider_key_alias"></a> [cluster\_encryption\_config\_provider\_key\_alias](#output\_cluster\_encryption\_config\_provider\_key\_alias) | Cluster Encryption Config KMS Key Alias ARN |
 | <a name="output_cluster_encryption_config_provider_key_arn"></a> [cluster\_encryption\_config\_provider\_key\_arn](#output\_cluster\_encryption\_config\_provider\_key\_arn) | Cluster Encryption Config KMS Key ARN |
 | <a name="output_cluster_encryption_config_resources"></a> [cluster\_encryption\_config\_resources](#output\_cluster\_encryption\_config\_resources) | Cluster Encryption Config Resources |
+| <a name="output_eks_addons_versions"></a> [eks\_addons\_versions](#output\_eks\_addons\_versions) | Map of enabled EKS Addons names and versions |
 | <a name="output_eks_cluster_arn"></a> [eks\_cluster\_arn](#output\_eks\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
 | <a name="output_eks_cluster_certificate_authority_data"></a> [eks\_cluster\_certificate\_authority\_data](#output\_eks\_cluster\_certificate\_authority\_data) | The Kubernetes cluster certificate authority data |
 | <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | The endpoint for the Kubernetes API server |

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,14 @@ output "eks_cluster_ipv6_service_cidr" {
   value       = one(aws_eks_cluster.default[*].kubernetes_network_config[0].service_ipv6_cidr)
 }
 
+output "eks_addons_versions" {
+  description = "Map of enabled EKS Addons names and versions"
+  value = local.enabled ? {
+    for addon in aws_eks_addon.cluster :
+    addon.addon_name => addon.addon_version
+  } : {}
+}
+
 output "cluster_encryption_config_enabled" {
   description = "If true, Cluster Encryption Configuration is enabled"
   value       = var.cluster_encryption_config_enabled


### PR DESCRIPTION
## what

* Output `addons_version` if the EKS addons are enabled (var.addons)

## why

* This may be just my use case, but I have both a variable and a data source for fetching an addon version (the former to overwrite the latter) and the module's addon_version output would become the source of truth for the versions, e.g.

```hcl
addon_version = try(var.addons_versions["coredns"], data.aws_eks_addon_version.latest["coredns"].version)
```

## references

* N/A
