### PR TITLE
feat: allow eks addons to use pod identity associations

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.74"
+      version = ">= 5.75"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75"
+      version = ">= 5.77"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ resource "aws_eks_addon" "cluster" {
   resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts_on_create", try(replace(each.value.resolve_conflicts, "PRESERVE", "NONE"), null))
   resolve_conflicts_on_update = lookup(each.value, "resolve_conflicts_on_update", lookup(each.value, "resolve_conflicts", null))
   service_account_role_arn    = lookup(each.value, "service_account_role_arn", null)
+  pod_identity_association    = lookup(each.value, "pod_identity_association", null)
 
   tags = module.label.tags
 

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,17 @@ resource "aws_eks_addon" "cluster" {
   resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts_on_create", try(replace(each.value.resolve_conflicts, "PRESERVE", "NONE"), null))
   resolve_conflicts_on_update = lookup(each.value, "resolve_conflicts_on_update", lookup(each.value, "resolve_conflicts", null))
   service_account_role_arn    = lookup(each.value, "service_account_role_arn", null)
-  pod_identity_association    = lookup(each.value, "pod_identity_association", null)
+
+  pod_identity_association = lookup(each.value, "pod_identity_association", null)
+
+  dynamic "pod_identity_association" {
+    for_each = try(lookup(each.value, "pod_identity_association", null), null) != null ? [true] : []
+
+    content {
+      role_arn        = try(lookup(each.value.pod_identity_association, "role_arn"), null)
+      service_account = try(lookup(each.value.pod_identity_association, "service_account"), null)
+    }
+  }
 
   tags = module.label.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,5 @@
 # tflint-ignore: terraform_unused_declarations
 variable "region" {
-
   type        = string
   description = "OBSOLETE (not needed): AWS Region"
   default     = null
@@ -175,6 +174,10 @@ variable "addons" {
     create_timeout              = optional(string, null)
     update_timeout              = optional(string, null)
     delete_timeout              = optional(string, null)
+    pod_identity_association = optional(object({
+      role_arn        = string
+      service_account = string
+    }))
   }))
   description = <<-EOT
     Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources.

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.0"
+      version = ">= 5.77.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.74.0"
+      version = ">= 5.75.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- feat: allow eks addons to use pod identity associations

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Option to use a pod identity association instead of an IRSA

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#pod_identity_association
- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.75.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for pod identity associations in EKS addons, allowing IAM roles to be linked with Kubernetes service accounts.
	- Added a new optional field for specifying pod identity associations in the configuration.

- **Updates**
	- Updated the required version for the AWS provider to ">= 5.75".

- **Deprecation**
	- Marked the `region` variable as obsolete, indicating it is no longer needed for future configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->