### PR TITLE
Add support for upgrade policy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ Available targets:
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch the cluster in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_upgrade_policy"></a> [upgrade\_policy](#input\_upgrade\_policy) | Configuration block for the support policy to use for the cluster | <pre>object({<br/>    support_type = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_zonal_shift_config"></a> [zonal\_shift\_config](#input\_zonal\_shift\_config) | Configuration block with zonal shift configuration for the cluster | <pre>object({<br/>    enabled = optional(bool, null)<br/>  })</pre> | `null` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -109,6 +109,7 @@
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch the cluster in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_upgrade_policy"></a> [upgrade\_policy](#input\_upgrade\_policy) | Configuration block for the support policy to use for the cluster | <pre>object({<br/>    support_type = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_zonal_shift_config"></a> [zonal\_shift\_config](#input\_zonal\_shift\_config) | Configuration block with zonal shift configuration for the cluster | <pre>object({<br/>    enabled = optional(bool, null)<br/>  })</pre> | `null` | no |
 
 ## Outputs

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -50,6 +50,10 @@ addons = [
   },
 ]
 
+upgrade_policy = {
+  support_type = "STANDARD"
+}
+
 zonal_shift_config = {
   enabled = true
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -113,6 +113,7 @@ module "eks_cluster" {
   addons                                = local.addons
   addons_depends_on                     = [module.eks_node_group]
   bootstrap_self_managed_addons_enabled = var.bootstrap_self_managed_addons_enabled
+  upgrade_policy                        = var.upgrade_policy
   zonal_shift_config                    = var.zonal_shift_config
 
   access_entry_map = local.access_entry_map

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -115,6 +115,14 @@ variable "bootstrap_self_managed_addons_enabled" {
   default     = null
 }
 
+variable "upgrade_policy" {
+  type = object({
+    support_type = optional(string, null)
+  })
+  description = "Configuration block for the support policy to use for the cluster"
+  default     = null
+}
+
 variable "zonal_shift_config" {
   type = object({
     enabled = optional(bool, null)

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,13 @@ resource "aws_eks_cluster" "default" {
     }
   }
 
+  dynamic "upgrade_policy" {
+    for_each = var.upgrade_policy != null ? [var.upgrade_policy] : []
+    content {
+      support_type = upgrade_policy.value.support_type
+    }
+  }
+
   dynamic "zonal_shift_config" {
     for_each = var.zonal_shift_config != null ? [var.zonal_shift_config] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -203,6 +203,14 @@ variable "bootstrap_self_managed_addons_enabled" {
   default     = null
 }
 
+variable "upgrade_policy" {
+  type = object({
+    support_type = optional(string, null)
+  })
+  description = "Configuration block for the support policy to use for the cluster"
+  default     = null
+}
+
 variable "zonal_shift_config" {
   type = object({
     enabled = optional(bool, null)


### PR DESCRIPTION
## what

Add module variable to set `aws_eks_cluster`'s `upgrade_policy`.

## why

I need to be able to downgrade EKS support policy from default "Extedned" to "Standard".

## references

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#upgrade_policy

https://aws.amazon.com/about-aws/whats-new/2024/07/amazon-eks-controls-kubernetes-version-support-policy/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `upgrade_policy` for configuring the support policy of the EKS cluster.
	- Added a new variable `zonal_shift_config` to the Terraform configuration.
  
- **Documentation**
	- Updated README and Terraform documentation to include details about the new `upgrade_policy` input.
	- Enhanced clarity and comprehensiveness of existing inputs and outputs documentation.
	- Added examples for the `upgrade_policy` configuration in the fixtures and variable files.

- **Bug Fixes**
	- Updated default values for existing variables to improve clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->