### PR TITLE
feat: add deletion protection option to EKS cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ resource "aws_eks_cluster" "default" {
   version                       = var.kubernetes_version
   enabled_cluster_log_types     = var.enabled_cluster_log_types
   bootstrap_self_managed_addons = local.effective_bootstrap_self_managed_addons
+  deletion_protection           = var.deletion_protection_enabled
 
   access_config {
     authentication_mode                         = var.access_config.authentication_mode

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "bootstrap_self_managed_addons_enabled" {
   default     = null
 }
 
+variable "deletion_protection_enabled" {
+  description = " Whether to enable deletion protection for the cluster. When enabled, the cluster cannot be deleted unless deletion protection is first disabled."
+  type        = bool
+  default     = false
+}
+
 variable "auto_mode_compute_config" {
   description = <<-EOT
     EKS Auto Mode compute configuration. When enabled, AWS manages node


### PR DESCRIPTION
## what

- Added a new `deletion_protection_enabled` variable for configuring EKS cluster deletion protection.
- Wired the variable to the EKS cluster deletion protection setting.
- Defaulted the variable to `false` to preserve existing behavior.

## why

- Allows users to prevent accidental EKS cluster deletion when needed.
- Keeps deletion protection opt-in so existing deployments are not affected.

## references

- AWS EKS deletion protection documentation: https://docs.aws.amazon.com/eks/latest/userguide/deletion-protection.html
