### PR TITLE
feat: support preserve and namespace_config on EKS add-ons

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -254,6 +254,15 @@ resource "aws_eks_addon" "cluster" {
   resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts_on_create", try(replace(each.value.resolve_conflicts, "PRESERVE", "NONE"), null))
   resolve_conflicts_on_update = lookup(each.value, "resolve_conflicts_on_update", lookup(each.value, "resolve_conflicts", null))
   service_account_role_arn    = lookup(each.value, "service_account_role_arn", null)
+  preserve                    = lookup(each.value, "preserve", null)
+
+  dynamic "namespace_config" {
+    for_each = lookup(each.value, "namespace", null) != null ? [each.value.namespace] : []
+
+    content {
+      namespace = namespace_config.value
+    }
+  }
 
   dynamic "pod_identity_association" {
     for_each = merge({}, lookup(each.value, "pod_identity_association", {}))

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,8 @@ variable "addons" {
     resolve_conflicts_on_create = optional(string, null)
     resolve_conflicts_on_update = optional(string, null)
     service_account_role_arn    = optional(string, null)
+    preserve                    = optional(bool, null)
+    namespace                   = optional(string, null)
     pod_identity_association    = optional(map(string), {})
     create_timeout              = optional(string, null)
     update_timeout              = optional(string, null)
@@ -185,6 +187,13 @@ variable "addons" {
     `resolve_conflicts` will be used instead. If `resolve_conflicts_on_create` is
     not set and `resolve_conflicts` is `PRESERVE`, `resolve_conflicts_on_create`
     will be set to `NONE`.
+    If `preserve` is `true`, the add-on's Kubernetes resources (e.g. the CoreDNS,
+    VPC CNI, or kube-proxy DaemonSets/Deployments) are left running when the
+    add-on is removed from Terraform management, rather than being deleted. This
+    is useful when handing an add-on off to another manager, such as EKS Auto Mode.
+    If `namespace` is set, the add-on's Kubernetes resources are created in that
+    namespace instead of the add-on's default namespace. Only supported by add-ons
+    that allow a configurable namespace.
     If `additional_tags` are specified, they are added to the standard resource tags.
     EOT
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25.0"
+      version = ">= 6.42.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## what

- Expose the `preserve` argument on the `addons` variable, plumbed through to the `aws_eks_addon` resource.
- Expose the add-on `namespace` (via the resource's `namespace_config` block) on the `addons` variable.
- Both fields are optional and default to `null`, so behavior is unchanged for existing callers.

## why

- When an add-on is removed from Terraform management (for example when handing CoreDNS, the VPC CNI, or kube-proxy off to EKS Auto Mode), the module previously destroyed it with `preserve` defaulting to `false`, tearing down the underlying DaemonSet/Deployment. Setting `preserve = true` leaves the running Kubernetes resources in place so the hand-off is non-disruptive.
- `namespace_config` lets add-ons that support a configurable namespace install their resources into a custom namespace, which the module had no way to set.
- These were the only remaining configurable arguments of `aws_eks_addon` not surfaced by the module (the per-resource `region` override is intentionally left out to avoid drift on a regional cluster).

## references

- [`aws_eks_addon` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon)